### PR TITLE
fix(yelp): correct pagination offset increment logic (#48)

### DIFF
--- a/docs/features/2026-07-25-yelp-pagination-fix.md
+++ b/docs/features/2026-07-25-yelp-pagination-fix.md
@@ -1,0 +1,18 @@
+# 修復 Yelp API 分頁邏輯 Bug
+
+## What (做什麼)
+修改 Yelp API 搜尋功能的分頁 (`offset`) 遞增邏輯，以確保分頁資料能正確載入。目前的實作中，每次請求分頁只將 `offset` 增加 1，這會導致極嚴重的資料重複與無法正確載入下一頁資料。正確的分頁邏輯應該是每次將 `offset` 增加每一頁的數量 (`limit`)。
+
+## Why (為什麼做)
+目前在 `MainRepository` 中，當觸發分頁時，傳給 Yelp API 的 offset 參數使用了 `++this._offset`。
+Yelp API 的 `offset` 代表的是項目的起始位置。如果 `limit` 設為 50，下一頁的 `offset` 應該是 50，再下一頁是 100。
+但目前邏輯會變成第一頁是 `offset=1`，第二頁是 `offset=2`，導致第二頁返回的結果有 49 筆是第一頁已經顯示過的資料，造成畫面出現大量重複的餐廳項目。
+
+## 驗收條件 (Acceptance Criteria)
+- [ ] 每次載入下一頁時，Yelp API 請求的 `offset` 應該正確增加 `_MAX_ITEMS_COUNT_IN_LIST` (50)。
+- [ ] 第一頁的 `offset` 應為 0。
+- [ ] 不再出現重複的餐廳資料載入。
+
+## 範圍邊界 (Out of Scope)
+- 暫不調整 Yelp API 其他查詢參數或重新設計搜尋邏輯。
+- 不修改 UI 觸發分頁的方式。

--- a/docs/plans/2026-07-25-yelp-pagination-fix.md
+++ b/docs/plans/2026-07-25-yelp-pagination-fix.md
@@ -1,0 +1,28 @@
+# 實作計畫：修復 Yelp API 分頁邏輯 Bug
+
+## 檔案異動
+- `lib/flow/main/repository/main_repository.dart`
+
+## 資料結構與架構設計
+- 不變更現有架構或資料結構。
+- `MainRepository` 中的 `_offset` 變數將維持 `int` 類型，並依舊於 `reset()` 方法中歸零。
+- 修改點在於 `fetchYelpSearchInfo` 中呼叫 API 後的 offset 更新方式：從錯誤的 `++this._offset` 修正為 `this._offset += MainRepository._MAX_ITEMS_COUNT_IN_LIST`。
+
+## 任務拆分
+
+### 任務 1：修復 `MainRepository` 的分頁 offset 更新邏輯
+- **說明**：將 Yelp API 請求時的 offset 參數修正，並在請求成功後正確將 offset 加上每頁載入數量（limit）。
+- **步驟**：
+  1. 打開 `lib/flow/main/repository/main_repository.dart`。
+  2. 在 `fetchYelpSearchInfo` 內，將 `apiInstance.businessesSearch` 呼叫的參數 `offset: ++this._offset` 替換為 `offset: this._offset`。
+  3. 在 `apiInstance.businessesSearch` 呼叫結束並成功返回後（或在該方法適當的成功區段），加入 `this._offset += MainRepository._MAX_ITEMS_COUNT_IN_LIST;` 以遞增下次的分頁起始位置。
+- **預計時間**：2 分鐘
+
+### 任務 2：靜態分析與編譯檢查
+- **說明**：確保修改沒有引入語法錯誤。
+- **步驟**：
+  1. 執行 `flutter analyze` 檢查潛在問題。
+- **預計時間**：1 分鐘
+
+## 執行方式
+單一檔案、單一邏輯修改，將採用循序 (sequence) 的 Subagent-driven 或直接由主協調者 (Orchestrator) 單獨完成。不需要平行處理。

--- a/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
@@ -40,29 +40,33 @@ class MainRepository {
     }
 
     this._isLoading = true;
-    YelpSearchInfo searchInfo = await apiInstance.businessesSearch(
-        term: "Restaurants",
-        latitude: lat,
-        longitude: lng,
-        locale: Constants.LOCALE,
-        price: price,
-        openAt: openAt,
-        sortBy: sortByStr,
-        limit: MainRepository._MAX_ITEMS_COUNT_IN_LIST,
-        offset: this._offset);
-    this._isLoading = false;
-    this._offset += MainRepository._MAX_ITEMS_COUNT_IN_LIST;
+    try {
+      YelpSearchInfo searchInfo = await apiInstance.businessesSearch(
+          term: "Restaurants",
+          latitude: lat,
+          longitude: lng,
+          locale: Constants.LOCALE,
+          price: price,
+          openAt: openAt,
+          sortBy: sortByStr,
+          limit: MainRepository._MAX_ITEMS_COUNT_IN_LIST,
+          offset: this._offset);
 
-    Map<String, dynamic> favorsMap = await this._fetchFavorsMap();
+      Map<String, dynamic> favorsMap = await this._fetchFavorsMap();
 
-    // 檢查是否為最愛店家
-    searchInfo.businesses?.forEach((summaryInfo) {
-      summaryInfo.favor = (favorsMap.containsKey(summaryInfo.id));
-    });
-    this.summaryInfoSet.addAll(searchInfo.businesses ?? []);
+      // 檢查是否為最愛店家
+      searchInfo.businesses?.forEach((summaryInfo) {
+        summaryInfo.favor = (favorsMap.containsKey(summaryInfo.id));
+      });
+      this.summaryInfoSet.addAll(searchInfo.businesses ?? []);
 
-    // Reference ref = FirebaseStorage.instance.ref("Gh3CuBx9LrhoTrBveY4B2OBLWvj2/test.png");
-    return await this.filterByKeyword(this._keyword, sortByStr);
+      this._offset += MainRepository._MAX_ITEMS_COUNT_IN_LIST;
+
+      // Reference ref = FirebaseStorage.instance.ref("Gh3CuBx9LrhoTrBveY4B2OBLWvj2/test.png");
+      return await this.filterByKeyword(this._keyword, sortByStr);
+    } finally {
+      this._isLoading = false;
+    }
   }
 
   Future<List<YelpRestaurantSummaryInfo>> filterByKeyword(

--- a/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
@@ -49,8 +49,10 @@ class MainRepository {
         openAt: openAt,
         sortBy: sortByStr,
         limit: MainRepository._MAX_ITEMS_COUNT_IN_LIST,
-        offset: ++this._offset);
+        offset: this._offset);
     this._isLoading = false;
+    this._offset += MainRepository._MAX_ITEMS_COUNT_IN_LIST;
+
     Map<String, dynamic> favorsMap = await this._fetchFavorsMap();
 
     // 檢查是否為最愛店家

--- a/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/main/repository/main_repository.dart
@@ -64,6 +64,9 @@ class MainRepository {
 
       // Reference ref = FirebaseStorage.instance.ref("Gh3CuBx9LrhoTrBveY4B2OBLWvj2/test.png");
       return await this.filterByKeyword(this._keyword, sortByStr);
+    } on Exception catch (e, st) {
+      logger.e('fetchYelpSearchInfo 發生異常', error: e, stackTrace: st);
+      rethrow;
     } finally {
       this._isLoading = false;
     }


### PR DESCRIPTION
## Summary
修復 Yelp API 搜尋功能中，分頁載入時 offset 遞增錯誤導致大量重複資料的問題。

## 修正問題 (Problem)
在 `MainRepository` 中，當觸發分頁載入下一頁時，傳給 Yelp API 的 `offset` 參數使用了 `++this._offset`。
這導致原先預期應增加 50（即 `_MAX_ITEMS_COUNT_IN_LIST`）的 offset，實際上每次只增加了 1。
其結果是，第二頁的回傳內容中有 49 筆是第一頁的重複資料，無法正確顯示下一頁的全新餐廳。

## 修正方式 (Fix)
1. **修改 API 參數**: 將 `businessesSearch` 的 `offset` 參數從 `++this._offset` 改為正確地讀取當下的 `this._offset`。
2. **正確遞增 Offset**: 在 API 成功回傳後，將 `this._offset` 遞增 `MainRepository._MAX_ITEMS_COUNT_IN_LIST` (50)，為下次載入下一頁作好準備。

## 關聯 Issue
Fixes #48

## Summary by Sourcery

Fix Yelp search pagination offset handling to prevent duplicate results when loading additional pages.

Bug Fixes:
- Correct Yelp businesses search offset parameter to use the current offset value instead of pre-incrementing it by one.
- Increment the stored pagination offset by the page size after a successful API response to align subsequent page requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Yelp restaurant search pagination so the “next page” offset advances by the expected page size, preventing repeated or missing results.
  * Improved search loading state handling to ensure it correctly resets after the full request flow, even if something fails.
* **Documentation**
  * Added release notes and an implementation plan describing the Yelp pagination offset fix, including acceptance criteria and scope boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->