### PR TITLE
chore: Reorder drawer menu items for better usability

### DIFF
--- a/flutter_restaruant/flutter_restaruant/docs/features/2026-07-26-drawer-menu-reorder.md
+++ b/flutter_restaruant/flutter_restaruant/docs/features/2026-07-26-drawer-menu-reorder.md
@@ -1,0 +1,21 @@
+# 功能規格：調整側選單功能項目順序
+
+## 1. 使用者故事 (What & Why)
+目前側邊選單（Drawer）的首位項目為「設定 (Settings)」，這不符合一般使用者的操作直覺。
+為了提升使用者體驗，我們需要將「搜尋」、「篩選」與「口袋名單」等高頻率使用的核心功能移至上方，並將較少使用的「設定」移至選單最底部。
+
+## 2. 驗收條件 (Acceptance Criteria)
+- [ ] 側邊選單的項目順序應調整為以下優先級：
+  1. 關鍵字搜尋 (Keyword Search)
+  2. 篩選條件 (Filter Rules)
+  3. 切換 地圖/列表 模式 (Map/List Mode)
+  4. 我的位置 (Map My Loc)
+  5. 口袋名單 (Favorite)
+  6. 設定 (Settings)
+- [ ] 所有項目的點擊功能 (`onTap`) 必須保持原有的導航與重置邏輯不變。
+- [ ] 測試驗證：開啟 Drawer 時，視覺順序符合上述要求，且點擊各項目皆能正確進入對應功能。
+
+## 3. 範圍邊界 (Out of Scope)
+- 不改變 `DrawerHeader` 的樣式與內容。
+- 不新增任何新的選單項目或更改現有的圖示、文字多國語系 (i18n) 鍵值。
+- 本次僅針對 `lib/flow/main/view/main_page.dart` 中 `_buildDrawer` 方法內的 `ListTile` 順序進行調整。

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-07-26-drawer-menu-reorder.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-07-26-drawer-menu-reorder.md
@@ -1,0 +1,23 @@
+# 實作計畫：調整側選單功能項目順序
+
+## 1. 異動檔案
+- `lib/flow/main/view/main_page.dart`
+
+## 2. 實作細節 (How)
+這是一個單純的 UI 佈局調整。在 `_buildDrawer` 方法中，有一個 `ListView`，裡面包含了 `DrawerHeader` 與數個 `ListTile`。
+我們需要將這些 `ListTile` 的順序重新排列如下：
+1. `appLocalizations.keyword_search` (搜尋)
+2. `appLocalizations.filter_rules` (篩選)
+3. `appLocalizations.map_mode` / `appLocalizations.list_mode` (地圖/列表切換)
+4. `appLocalizations.map_my_loc_title` (我的位置)
+5. `appLocalizations.favorite_store_add` (口袋名單)
+6. `appLocalizations.settings_title` (設定)
+
+無須修改任何回呼函數（`onTap`）的內部邏輯，僅剪下貼上調整順序。
+
+## 3. 任務拆分
+- **Task 1**: 修改 `lib/flow/main/view/main_page.dart` 內的 `_buildDrawer` 方法，依據上述順序重排 `ListTile`。
+- **Task 2**: 進行建置與視覺驗收，確認順序變更無誤。
+
+## 4. 並行模式判斷
+- 任務皆為單一檔案的線性修改，無需並行處理。

--- a/flutter_restaruant/flutter_restaruant/lib/flow/main/view/main_page.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/main/view/main_page.dart
@@ -136,21 +136,21 @@ class MainPageState extends State<MainPage> implements AppOpenADEvent {
                       fontSize: UIConstants.xxxhFontSize,
                       fontWeight: FontWeight.bold)))),
       ListTile(
-          leading: Icon(Icons.settings, color: ColorName.appPrimaryColor),
-          title: Text(appLocalizations.settings_title),
+          leading: Icon(Icons.search, color: ColorName.appPrimaryColor),
+          title: Text(appLocalizations.keyword_search),
           onTap: () {
             Navigator.of(context).pop();
             _runAfterDrawerClosed(() {
-              Navigator.of(this.context).pushNamed(SettingsPage.ROUTE_NAME);
+              _showKeywordDialog();
             });
           }),
       ListTile(
-          leading: Icon(Icons.favorite, color: ColorName.appPrimaryColor),
-          title: Text(appLocalizations.favorite_store_add),
+          leading: Icon(Icons.filter_list, color: ColorName.appPrimaryColor),
+          title: Text(appLocalizations.filter_rules),
           onTap: () {
             Navigator.of(context).pop();
             _runAfterDrawerClosed(() {
-              Navigator.of(this.context).pushNamed(FavorPage.ROUTE_NAME);
+              _openFilterPage();
             });
           }),
       ListTile(
@@ -180,21 +180,21 @@ class MainPageState extends State<MainPage> implements AppOpenADEvent {
             });
           }),
       ListTile(
-          leading: Icon(Icons.search, color: ColorName.appPrimaryColor),
-          title: Text(appLocalizations.keyword_search),
+          leading: Icon(Icons.favorite, color: ColorName.appPrimaryColor),
+          title: Text(appLocalizations.favorite_store_add),
           onTap: () {
             Navigator.of(context).pop();
             _runAfterDrawerClosed(() {
-              _showKeywordDialog();
+              Navigator.of(this.context).pushNamed(FavorPage.ROUTE_NAME);
             });
           }),
       ListTile(
-          leading: Icon(Icons.filter_list, color: ColorName.appPrimaryColor),
-          title: Text(appLocalizations.filter_rules),
+          leading: Icon(Icons.settings, color: ColorName.appPrimaryColor),
+          title: Text(appLocalizations.settings_title),
           onTap: () {
             Navigator.of(context).pop();
             _runAfterDrawerClosed(() {
-              _openFilterPage();
+              Navigator.of(this.context).pushNamed(SettingsPage.ROUTE_NAME);
             });
           })
     ])));


### PR DESCRIPTION
## Summary
這個 PR 調整了側邊選單 (Drawer) 中 `ListTile` 的視覺排列順序，以符合使用者的操作直覺，提升 UX 體驗。

## 修正問題與方式
* **修正了什麼**：高頻核心功能（如搜尋、篩選）原本排序在不直覺的位置，且「設定」位於首位。
* **修正方式**：在 `lib/flow/main/view/main_page.dart` 中重新排列了選單項目的渲染順序。更新後的順序為：
  1. 關鍵字搜尋
  2. 篩選條件
  3. 地圖/列表切換
  4. 我的位置
  5. 口袋名單
  6. 設定
* **無副作用**：點擊邏輯 (onTap) 與圖示語系皆未改動。

Fixes #51

## Summary by Sourcery

Reorder the main drawer menu items to prioritize high-frequency actions and move settings to the bottom for more intuitive navigation.

Documentation:
- Add an implementation plan document describing the drawer menu reorder change.
- Add a feature specification document defining the desired drawer menu item order and acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Reordered the Drawer menu items for clearer access:
    * Keyword search
    * Filters
    * Map/List mode
    * My location
    * Pocket list
    * Settings
  * Existing navigation and tap actions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->