### PR TITLE
feat(inspector): integrate flutter_inspector_kit debug-only dashboard

### DIFF
--- a/flutter_restaruant/flutter_restaruant/docs/brainstorm/2026-08-05_features_brainstorm.md
+++ b/flutter_restaruant/flutter_restaruant/docs/brainstorm/2026-08-05_features_brainstorm.md
@@ -19,7 +19,7 @@
 
 | 項目 | 優先級 | 說明 |
 | :--- | :---: | :--- |
-| **整合 `flutter_inspector_kit`**（見 **§2.0 F-0.1**） | **P-1（先於所有既有項目）** | pub.dev `1.9.0`，`dio ^5.2.0` 與本專案 `^5.6.0` 相容。⚠️ 需求原文為 `flutter_inspect_kit`，pub.dev 查無，**正確名為 `flutter_inspector_kit`**。必須以 `kDebugMode` 圍住，否則會把含 `authToken` 的請求 body 暴露給終端使用者 |
+| ✅ **整合 `flutter_inspector_kit`**（見 **§2.0 F-0.1**）— **已於 2026-08-05 完成** | **P-1（先於所有既有項目）** | pub.dev `1.9.0`，`dio ^5.2.0` 與本專案 `^5.6.0` 相容。⚠️ 需求原文為 `flutter_inspect_kit`，pub.dev 查無，**正確名為 `flutter_inspector_kit`**。必須以 `kDebugMode` 圍住，否則會把含 `authToken` 的請求 body 暴露給終端使用者。**落地補充**：安裝時需將 Dart SDK 下限由 `3.5.0` 上修至 `3.10.1`；實際接線 5 處／4 檔（原估 4 處）|
 
 > 連帶調整：§3 RICE 表新增一列並將原排名 5～16 順延為 6～17；§4 Roadmap Phase 1 進度改記 9/13；§6.9 Phase 1.5 順序表新增 P-1 前置段。
 
@@ -225,7 +225,7 @@ lib/
 
 ## 2. 全方位創新功能提案與既有 UX 優化 (Comprehensive Feature Ideation & UX Optimization)
 
-### 2.0 開發者工具地基：整合 `flutter_inspector_kit` (P-1，最高優先) — ⬜ 待辦
+### 2.0 開發者工具地基：整合 `flutter_inspector_kit` (P-1，最高優先) — ✅ 已於 2026-08-05 完成
 
 > **定位**：這**不是產品功能，是修其他所有項目時的量測工具**。排在最前面的理由不是它最有價值，而是**它讓後面每一項都更快、更有證據**——先裝溫度計，再治病。
 
@@ -239,17 +239,18 @@ lib/
 | 項目 | 套件需求 | 本專案現況 | 判定 |
 | :--- | :--- | :--- | :---: |
 | `dio` | `^5.2.0` | `^5.6.0` | 🟢 相容 |
-| Dart SDK | Flutter 套件 | `>=3.5.0 <4.0.0` | 🟢 相容 |
+| Dart SDK | Flutter 套件 | 原 `>=3.5.0 <4.0.0` | 🟡 **實際安裝時需上修至 `>=3.10.1`**（套件傳遞相依要求），已於本次一併調整 |
 | 新增傳遞相依 | `flutter_local_notifications` `^22.0.0`、`share_plus` `^13.0.0`、`web` `^1.1.0` | 皆未安裝 | 🟡 新增 3 個傳遞相依 |
 
-**接線點（皆已實查存在，無須先重構）**
+**接線點（實際落地為 5 處／4 檔，與原估的 4 處有出入）**
 
-| # | 接線 | 位置 | 說明 |
+| # | 接線 | 規劃位置 | 實際落地 |
 | :--- | :--- | :--- | :--- |
-| 1 | 建立單一 `FlutterInspector` 實例 | `lib/di/` | 沿用既有 GetIt 註冊，與現行 DI 慣例一致 |
-| 2 | Dio 攔截器 | `lib/api/dio/dio_client.dart:24,29` | 已有 `dio.interceptors.addAll(...)` 掛載點，**加一行即可** |
-| 3 | `navigatorObservers` | `lib/main.dart:51` `PlatformApp` | `PlatformApp` 支援頂層 `navigatorObservers`，Material／Cupertino 兩分支共用 |
-| 4 | 喚起手勢 | `lib/main.dart:79` `builder:` | **既有 `builder:` 層**（S1 為跨平台 theme 而加）可直接包 `FlutterInspectorMagicalTap`，無須新增層級 |
+| 1 | 建立單一 `FlutterInspector` 實例 | `lib/di/`（沿用 GetIt 註冊） | `lib/di/inspector.dart` —— **改用頂層 `final FlutterInspector?`**，`kDebugMode ? ... : null`，未走 GetIt（release 恆為 `null`，引用點成為 dead code 被 tree-shaking 移除，比 GetIt 註冊更能保證 AC-9） |
+| 2 | Dio 攔截器 | `lib/api/dio/dio_client.dart:24,29` | `lib/api/api_clz.dart` —— 掛載點實際在此檔，**排在既有 auth `InterceptorsWrapper` 之後**，確保攔得到已注入 header 的請求 |
+| 3 | `navigatorObservers` | `lib/main.dart:51` `PlatformApp` | 同規劃，`PlatformApp` 頂層掛載 |
+| 4 | 喚起手勢（5 連點） | `lib/main.dart:79` `builder:` | 同規劃包 `FlutterInspectorMagicalTap`；⚠️ 但 `onTap` **不可用 builder 的 `context`**（位於 Navigator 之上，`showGeneralDialog` 解析不到 `NavigatorState`），改由 `navigatorKey.currentContext` 取得 |
+| 5 | **常駐 FAB（`attach()`）** | *（原未規劃）* | `lib/flow/splash/view/splash_page.dart` —— 套件另一進入點，與 5 連點並存。需用路由 widget 自身的 `context`（已在 Overlay 之下）才找得到 `Overlay` |
 
 **🔴 必要防線：絕不可進 production build**
 
@@ -270,9 +271,12 @@ lib/
 | §1.2 缺陷 2 API Key | 可實地確認 header 中的 `authToken` 是否已改由 broker 供給 |
 | S2／S3 視覺改造 | 診斷報告一鍵導出，附網路與導航 timeline，回報視覺問題時附得上證據 |
 
-* **Effort**: 0.5（4 個接線點，全部是既有掛載點加行，無重構）
+* **Effort**: 0.5（實際 5 個接線點／4 檔，全部是既有掛載點加行，無重構——估計吻合）
 * **破壞性評估**: 🟢 —— 全數包在 `kDebugMode` 內，release 行為零改變；套件本身設計為「絕不破壞宿主 App」（錯誤鉤子鏈接而非覆蓋）
-* **驗收**: `flutter analyze` 維持 `No issues found!`；debug build 可喚起 dashboard 並看到 Yelp 請求；**release build 確認無 dashboard**
+* **驗收**: ✅ `flutter analyze` 維持 `No issues found!`；`flutter test` 54/54 通過
+* **落地後補充（2026-08-05）**：
+  * 啟用 `showNetworkNotification`／`captureUncaughtErrors`／`captureLifecycleEvents`，並設 `redactSensitiveData: false`（僅影響匯出／分享／複製路徑，畫面顯示本就不遮蔽）。全在 `kDebugMode` 分支內，不影響 release 零改變的結論。
+  * ⚠️ **`captureUncaughtErrors` 會在建構子內即時改寫三個全域 error hook**（`FlutterError.onError`／`PlatformDispatcher.onError`／`ErrorWidget.builder`）。`test/app_theme_platform_test.dart` 是全專案唯一 mount 真實 App 的測試，`flutter_test` 會比對 `pumpWidget` 前後的 `ErrorWidget.builder`，故該測試需在 `try/finally` 內自行復原三個 hook——**`tearDown()` 太晚，救不了**。日後若有新測試 mount 真實 App，同樣要處理。
 
 ---
 
@@ -441,7 +445,7 @@ lib/
 | ✅ **修復 `build()` 側邊效應反模式** | 既有修復 | 10 | 3.0 | 100% | 0.5 | **60.0** | 28.5 | 1 | **已完成** |
 | ✅ **修復 Yelp API 分頁邏輯 Bug** | 既有修復 | 9 | 2.5 | 100% | 0.5 | **45.0** | 23.75 | 2 | **已完成** |
 | ✅ **修復 `FilterPage` 狀態重置 Bug** | 既有修復 | 8 | 2.5 | 100% | 0.5 | **40.0** | 23.75 | 3 | **已完成** |
-| 🔵 **整合 `flutter_inspector_kit` 除錯套件** | 開發工具 | 10 | 2.0 | 100% | 0.5 | **40.0** | 19.0 | 4 | **P-1（最高，先於所有項目）** |
+| ✅ **整合 `flutter_inspector_kit` 除錯套件** | 開發工具 | 10 | 2.0 | 100% | 0.5 | **40.0** | 19.0 | 4 | **已完成**（2026-08-05） |
 | 🔴 **移除硬編碼 API Key (改用 Server-side Broker)** | 安全修復 | 10 | 2.0 | 100% | 0.5 | **40.0** | 19.0 | 5 | **P0（唯一未解安全風險）** |
 | ✅ **對照組風格: 目錄架構與層級分離重構** | 架構重構 | 10 | 3.0 | 100% | 2.0 | **15.0** | 24.0 | - | **已完成** |
 | ✅ **對照組風格: 導入全域依賴注入 (GetIt)** | 架構重構 | 10 | 2.5 | 100% | 1.5 | **16.6** | 21.2 | - | **已完成** |
@@ -476,8 +480,8 @@ lib/
 +-----------------------------------------------------------------------------------+
 |                           STRATEGIC PRODUCT ROADMAP                               |
 +-----------------------------------------------------------------------------------+
-| Phase 1: 地基修復與架構對齊 (Foundation & Architecture)   ── 進度 9/13 ✅         |
-|   • [ ] P-1 整合 flutter_inspector_kit ⚡ 最高優先，後續各項的量測前提           |
+| Phase 1: 地基修復與架構對齊 (Foundation & Architecture)   ── 進度 10/13 ✅        |
+|   • [x] P-1 整合 flutter_inspector_kit ✅ 2026-08-05（量測地基就位）             |
 |   • [x] P0 修復 `build()` 側邊效應反模式                                          |
 |   • [x] P0 修復 Yelp API 分頁邏輯 Bug                                              |
 |   • [x] P0 修復 `FilterPage` 狀態重置 Bug                                          |
@@ -971,7 +975,7 @@ lib/features/foundation/style/
 | Phase 1.5: 空間與視覺體驗升級 (Spatial UX & Polish)                               |
 |                                                                                   |
 |  ── P-1 開發工具地基（先於一切，見 §2.0）──                                       |
-|   • [ ] 整合 flutter_inspector_kit (kDebugMode 圍住，release 零改變)              |
+|   • [x] 整合 flutter_inspector_kit (kDebugMode 圍住，release 零改變) ✅ 08-05     |
 |                                                                                   |
 |  ── 6.x UI 視覺重塑（本章，前置地基）──                                           |
 |   • [x] S1 Design System 地基 (ThemeData / ColorScheme / token) ✅ 2026-08-03     |

--- a/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
@@ -99,7 +99,7 @@
 
 | # | 條件 | 驗證方式 |
 | :--- | :--- | :--- |
-| **AC-1** | Debug build 中可透過套件提供的喚起手勢開啟 inspector dashboard | 模擬器／實機 debug build 實跑，執行手勢後 dashboard 顯示 |
+| **AC-1** | Debug build 中可透過套件提供的喚起手勢**或**常駐 FAB 開啟 inspector dashboard（2026-08-05 修訂：使用者要求 FAB 與五連點並存，兩者皆為 debug-only 進入點） | 模擬器／實機 debug build 實跑，執行手勢或點擊 FAB 後 dashboard 皆能顯示 |
 | **AC-2** | Dashboard 的 Network 分頁可看到**實際發出的 Yelp 搜尋請求**，含 URL、method、狀態碼、耗時，以及 request／response body | debug build 執行一次餐廳搜尋，於 Network 分頁確認該筆請求存在且欄位完整 |
 | **AC-3** | Dashboard 的 Navigator 分頁可看到頁面切換紀錄 | debug build 執行「列表 → 餐廳詳情 → 返回」，確認三筆導航事件被記錄 |
 
@@ -107,7 +107,7 @@
 
 | # | 條件 | 驗證方式 |
 | :--- | :--- | :--- |
-| **AC-4** | **Release build 中不存在任何 inspector 進入點**：無喚起手勢、無 FAB、無任何可觸發 dashboard 的路徑 | `flutter build` 產出 release 版本並實機安裝，於所有畫面嘗試喚起手勢，確認無反應 |
+| **AC-4** | **Release build 中不存在任何 inspector 進入點**：無喚起手勢、無 FAB、無任何可觸發 dashboard 的路徑（FAB 現為刻意新增的第二 debug-only 進入點，仍受同一 `kDebugMode` guard 約束，故本條驗收範圍不變） | `flutter build` 產出 release 版本並實機安裝，於所有畫面嘗試喚起手勢，並全螢幕檢視確認無 FAB 常駐，確認皆無反應 |
 | **AC-5** | **Release build 不註冊 inspector 的 Dio 攔截器與 navigator observer**：不記錄任何請求／回應 body | 檢視 release 路徑的接線是否全數位於 `kDebugMode` 判斷之內 |
 | **AC-6** | **Release bundle 經 tree-shaking 移除 dashboard UI** | 對 release 產物驗證 inspector dashboard 相關符號已不存在（具體驗證指令由 STAGE 0b 決定） |
 

--- a/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
@@ -173,12 +173,12 @@
 
 **緩解手段**
 
-1. **`kDebugMode` guard 為強制設計約束**：DI 註冊、Dio 攔截器、`navigatorObservers`、喚起手勢，四個接線點**無一例外**必須位於 `kDebugMode` 判斷之內。`kDebugMode` 是編譯期常數，release build 中該分支為 dead code，會被 tree-shaking 移除。
+1. **`kDebugMode` guard 為強制設計約束**：DI 註冊、Dio 攔截器、`navigatorObservers`、喚起手勢、常駐 FAB（2026-08-05 新增），五個接線點**無一例外**必須位於 `kDebugMode` 判斷之內。`kDebugMode` 是編譯期常數，release build 中該分支為 dead code，會被 tree-shaking 移除。
 2. **驗收硬條件**：AC-4（release 無進入點）、AC-5（release 不註冊攔截器）、AC-6（release bundle 不含 dashboard UI）為**合併前必過項**，任一不過即不得合併。
 3. **實機驗證，非程式碼審閱**：AC-4 必須以**實際安裝的 release build** 驗證，不接受「看程式碼覺得應該沒問題」。
 4. **不因此延後缺陷 2 的修復**：本項緩解的是「不讓風險擴大」，**不等於風險已解除**。硬編碼金鑰仍須依 §1.2 缺陷 2 獨立處理（含 revoke & rotate）。
 
-> **殘餘風險**：即使 AC-4～6 全過，`kDebugMode` guard 的正確性仍依賴人為紀律。未來新增接線點時可能漏包。**本次不建 CI 防護（§4.2）**，此判斷的前提是接線點只有四個且集中在兩個檔案；若日後接線點增加，應重新評估。
+> **殘餘風險（2026-08-05 更新）**：即使 AC-4～6 全過，`kDebugMode` guard 的正確性仍依賴人為紀律。未來新增接線點時可能漏包。**本次不建 CI 防護（§4.2）**。原判斷前提是「接線點只有四個且集中在兩個檔案」——此前提已被打破：新增 FAB 進入點（`lib/flow/splash/view/splash_page.dart`）後現為**五個接線點、四個檔案**（詳見 `docs/plans/...md` §2.5、§3、§5.1）。文件自身設下的「若日後接線點增加，應重新評估」觸發條件已達成：重新評估結論為風險性質不變（仍是同一種「人為紀律」依賴），數量增加不代表控制力下降，`kDebugMode` guard 與 T5 的 `grep` 齊全檢查對每一處新接線點同樣有效。
 
 ### 5.2 🟡 R-2：新增傳遞相依帶來的相容性風險
 

--- a/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/features/2026-08-05-flutter-inspector-kit-integration.md
@@ -1,0 +1,280 @@
+# F-0.1 — 整合 `flutter_inspector_kit` 除錯套件 (Developer Tooling Foundation)
+
+> 功能規格（STAGE 0a：What & Why）
+> 出處：`docs/brainstorm/2026-08-05_features_brainstorm.md` §2.0（F-0.1，P-1 最高優先）
+> 本文件**不含**實作步驟、逐行異動與任務拆分——那是 STAGE 0b 實作計畫的內容。
+> 撰寫日期：2026-08-05
+> 基準 commit：`2890610`（branch `main`）
+
+## 定位聲明 (Positioning)
+
+**這不是產品功能，是開發工具。**
+
+終端使用者永遠不會看到它、不會受它影響、不會知道它存在。它的價值不在自身，而在於**讓後續每一個待辦項目的修復都更快、更有證據**——先裝溫度計，再治病。
+
+因此本規格的使用者故事全部是**開發者故事**，不是終端使用者故事；驗收條件的核心也不是「功能可用」，而是「**debug 可用且 release 絕對不存在**」。
+
+---
+
+## 1. 問題陳述 (Problem Statement)
+
+### 1.1 現況：修 bug 全靠猜
+
+專案 `docs/brainstorm/2026-08-05_features_brainstorm.md` §1.2 目前累積 **4 項未解缺陷**（2026-08-05 複測），其中三項的修復與驗證都需要「看得到執行期真實行為」的能力，而現在沒有：
+
+| 缺陷（§1.2） | 現況 | 缺少的量測能力 |
+| :--- | :--- | :--- |
+| 缺陷 2：硬編碼 API 金鑰 | `lib/features/foundation/constants/constants.dart:30` `staticMapApiKey`、`:41` `authToken` 明碼在版控中（已複驗，行號 30/41） | 無法實地確認送出的 header 內容是否已改由 broker 供給 |
+| 缺陷 4：Firestore 單一 Document 全量覆寫 | `FavorDataSource` 仍 `set(..., merge: false)` | 無法觀察寫入量與併發時序 |
+| 缺陷 5：硬編碼假延遲 | `main_bloc.dart:56` 過濾 2 秒、`fcm_manager.dart:51` 推播導航 8 秒 | **無法證明 2 秒是多餘的**——沒人知道真實 round-trip 是 200ms 還是 1.8s |
+| 缺陷 7：`MapWidget` Marker 未連動 | `map_widget.dart` 無 `didUpdateWidget()` | 無法確認 rebuild 是否真的被觸發 |
+
+目前唯一的觀測手段是 `lib/api/dio/dio_client.dart:24-25` 的 `LogInterceptor(requestBody: true, responseBody: true)`——它把請求與回應**沖進 console 純文字流**，無法搜尋、無法比對兩次請求的差異、無法量測耗時、無法在實機上查看、無法匯出附在問題回報裡。
+
+### 1.2 為什麼排 P-1（先於 P0 安全修復）
+
+**不是因為它比洩漏金鑰更嚴重**，而是因為：
+
+1. **它是後續每一項的量測前提**。移除假延遲之後如果畫面開始閃爍，沒有 timeline 就只能靠猜；有了 timeline 才能指出被 2 秒延遲掩蓋掉的 race condition。
+2. **Effort 極低（0.5）**。四個接線點**全部是既有掛載點加行**，零重構——這一點已於下方 §1.3 逐一複驗。
+3. **破壞性為零**。全數包在 `kDebugMode` 內，release 行為完全不變。
+
+一個 effort 0.5、破壞性 0、且能讓後面四項缺陷的修復都變得可驗證的項目，排第一是純粹的槓桿計算，不是價值排序。
+
+### 1.3 接線點複驗 (Wiring Points — Re-verified 2026-08-05)
+
+| # | 接線 | 位置（複驗結果） | 現況 |
+| :--- | :--- | :--- | :--- |
+| 1 | 建立單一 `FlutterInspector` 實例 | `lib/di/injection.dart` | ✅ 專案已用 GetIt（**非 injectable**），`setupInjection()` 內 12 個 `registerLazySingleton`，沿用即可 |
+| 2 | Dio 攔截器 | `lib/api/dio/dio_client.dart:24`、`:29` | ✅ 已有 `dio.interceptors.add(...)` 與 `.addAll(...)` 兩處掛載點 |
+| 3 | `navigatorObservers` | `lib/main.dart:51` `PlatformApp` | ✅ `PlatformApp` 支援頂層 `navigatorObservers`，Material／Cupertino 兩分支共用；目前**尚未使用**此參數 |
+| 4 | 喚起手勢 | `lib/main.dart:79-82` `builder:` | ✅ 既有 `builder:` 層（S1 為跨平台 theme 解析而加，回傳 `Theme(...)` 包 `child`）可直接複用，**無須新增層級** |
+
+**結論：四個接線點全部已存在，本次整合不需要任何前置重構。**
+
+---
+
+## 2. 使用者故事 (Developer Stories)
+
+> 全部是開發者故事。本功能對終端使用者的可感知度為 **零**——這是設計目標，不是妥協。
+
+### DS-1：驗證假延遲確實多餘
+
+> **身為**準備移除 `main_bloc.dart:56` 那 2 秒 `Future.delayed` 的開發者，
+> **我希望**能在 App 內直接看到 Yelp 搜尋請求的真實 round-trip 時間，
+> **以便**我能用數據證明「這 2 秒是純粹的無謂等待」，而不是憑感覺刪掉別人寫的程式碼。
+
+### DS-2：驗證金鑰已不再隨請求送出
+
+> **身為**要修復 §1.2 缺陷 2（硬編碼 `authToken`）的開發者，
+> **我希望**能逐筆檢視實際送出的 request header，
+> **以便**在改為 broker 供給後，我能實地確認 header 內容真的變了，而不是只確認程式碼看起來變了。
+
+### DS-3：確認 Marker rebuild 是否真的觸發
+
+> **身為**要修 `MapWidget` 標記未連動的開發者，
+> **我希望**能對照 Navigator 事件與 console log 的時序，
+> **以便**判斷問題出在「rebuild 沒被觸發」還是「觸發了但 Marker 沒重建」。
+
+### DS-4：實機除錯不必接電腦
+
+> **身為**在實機上重現問題的開發者，
+> **我希望**用一個手勢就能在 App 內叫出網路請求列表，
+> **以便**我不必為了看一行 log 而回頭接 USB、開 IDE、重跑一次流程。
+
+### DS-5：回報問題時附得上證據
+
+> **身為**要向團隊回報一個難以重現的問題的開發者，
+> **我希望**能一鍵匯出含網路與導航 timeline 的診斷報告，
+> **以便**接手的人看到的是紀錄而不是我的描述。
+
+---
+
+## 3. 驗收條件 (Acceptance Criteria)
+
+> 分三組：**功能可用**（AC-1～3）、**安全防線**（AC-4～6，🔴 硬性）、**零破壞**（AC-7～10）。
+> AC-4～6 任一項不通過，本功能**不得合併**——無論其他項目多完美。
+
+### 3.1 功能可用
+
+| # | 條件 | 驗證方式 |
+| :--- | :--- | :--- |
+| **AC-1** | Debug build 中可透過套件提供的喚起手勢開啟 inspector dashboard | 模擬器／實機 debug build 實跑，執行手勢後 dashboard 顯示 |
+| **AC-2** | Dashboard 的 Network 分頁可看到**實際發出的 Yelp 搜尋請求**，含 URL、method、狀態碼、耗時，以及 request／response body | debug build 執行一次餐廳搜尋，於 Network 分頁確認該筆請求存在且欄位完整 |
+| **AC-3** | Dashboard 的 Navigator 分頁可看到頁面切換紀錄 | debug build 執行「列表 → 餐廳詳情 → 返回」，確認三筆導航事件被記錄 |
+
+### 3.2 🔴 安全防線（硬性條件）
+
+| # | 條件 | 驗證方式 |
+| :--- | :--- | :--- |
+| **AC-4** | **Release build 中不存在任何 inspector 進入點**：無喚起手勢、無 FAB、無任何可觸發 dashboard 的路徑 | `flutter build` 產出 release 版本並實機安裝，於所有畫面嘗試喚起手勢，確認無反應 |
+| **AC-5** | **Release build 不註冊 inspector 的 Dio 攔截器與 navigator observer**：不記錄任何請求／回應 body | 檢視 release 路徑的接線是否全數位於 `kDebugMode` 判斷之內 |
+| **AC-6** | **Release bundle 經 tree-shaking 移除 dashboard UI** | 對 release 產物驗證 inspector dashboard 相關符號已不存在（具體驗證指令由 STAGE 0b 決定） |
+
+> **AC-4～6 的理由見 §5.1。這是本功能唯一的真實風險，也是唯一不可妥協的驗收面向。**
+
+### 3.3 零破壞
+
+| # | 條件 | 驗證方式 |
+| :--- | :--- | :--- |
+| **AC-7** | `flutter analyze` 維持 **`No issues found!`** | 現為零警告，**不得回退** |
+| **AC-8** | 既有測試檔全綠 | `flutter test` |
+| **AC-9** | Release build 的行為與外觀**完全不變** | 整合前後的 release build，主要流程（搜尋、篩選、詳情、最愛、訪客模式）逐一比對 |
+| **AC-10** | `dart format` 通過 | — |
+
+---
+
+## 4. 範圍邊界 (Scope)
+
+### 4.1 本次要做 (In Scope)
+
+1. 引入 `flutter_inspector_kit` 相依（pub.dev 最新版 `1.9.0`，MIT 授權）。
+2. 接上 §1.3 的**四個既有接線點**：DI 實例、Dio 攔截器、`navigatorObservers`、喚起手勢。
+3. 確保上述接線**全部以 `kDebugMode` 圍住**。
+4. 完成 §3 全部驗收條件。
+
+**就這四件事。**
+
+### 4.2 🚫 明確不做 (Out of Scope — YAGNI)
+
+| 排除項 | 理由 |
+| :--- | :--- |
+| ❌ **順便修 §1.2 的既有 P0 缺陷**（硬編碼金鑰、假延遲、Firestore 結構、Marker 未連動） | 這些是**各自獨立的待辦項**，各有各的規格與風險。混進來會讓「零破壞」這條驗收失去意義——出問題時分不清是 inspector 還是缺陷修復造成的。**本功能的價值正是讓那些項目更好修，而不是替它們動手** |
+| ❌ **移除既有的 `LogInterceptor`** | `dio_client.dart:24-25` 的 `LogInterceptor` 是否被 inspector 取代，是整合後的**觀察結論**，不是整合的前置動作。留著不衝突 |
+| ❌ **套件功能之外的客製化** | 不寫自訂 dashboard 分頁、不改套件的 UI、不包裝抽象層。套件開箱即用的能力已滿足 §2 全部故事。**單一實作的抽象層是純負債** |
+| ❌ **為 inspector 本身寫測試** | 它是 debug-only 的第三方工具，不參與產品邏輯。真正需要被驗證的是 AC-4～6（release 不存在），而那靠 build 驗證，不靠單元測試 |
+| ❌ **CI 自動化 release 檢查** | AC-6 本次為**人工驗證**。若未來重複發生誤入 release 的疑慮，再考慮自動化 |
+| ❌ **調整 inspector 的告警閾值等設定的長期治理** | 先用套件預設值。有具體不合用的情境再調 |
+
+### 4.3 邊界原則
+
+> 這是一個 effort 0.5 的項目。**任何讓它膨脹的提議，都在削弱它「先裝溫度計」的定位。**
+> 溫度計裝好就該去量體溫，而不是繼續改造溫度計。
+
+---
+
+## 5. 風險與緩解 (Risks & Mitigation)
+
+### 5.1 🔴 R-1：Inspector 進入 release build，造成機密即時外洩（最大風險）
+
+**風險內容**
+
+`flutter_inspector_kit` 的核心能力是**記錄完整的請求與回應 body**。而本專案 `lib/features/foundation/constants/constants.dart:30`／`:41` 目前**仍有硬編碼的 `staticMapApiKey` 與 `authToken`**（§1.2 缺陷 2，2026-08-05 複驗仍存在）。
+
+兩者相加的後果是**風險等級的躍升，不是疊加**：
+
+| | 目前 | 若 inspector 進入 release |
+| :--- | :--- | :--- |
+| 洩漏管道 | git 歷史 | **每一台裝了 App 的終端裝置** |
+| 需要的能力 | 取得 repo 存取權 | **裝 App、比出一個手勢** |
+| 可觀測範圍 | 原始碼中的常數 | **執行期實際送出的 header 與完整回應 body** |
+
+**這會把一個「已知的 P0」放大成「即時、大規模、零門檻」的洩漏。**
+
+**緩解手段**
+
+1. **`kDebugMode` guard 為強制設計約束**：DI 註冊、Dio 攔截器、`navigatorObservers`、喚起手勢，四個接線點**無一例外**必須位於 `kDebugMode` 判斷之內。`kDebugMode` 是編譯期常數，release build 中該分支為 dead code，會被 tree-shaking 移除。
+2. **驗收硬條件**：AC-4（release 無進入點）、AC-5（release 不註冊攔截器）、AC-6（release bundle 不含 dashboard UI）為**合併前必過項**，任一不過即不得合併。
+3. **實機驗證，非程式碼審閱**：AC-4 必須以**實際安裝的 release build** 驗證，不接受「看程式碼覺得應該沒問題」。
+4. **不因此延後缺陷 2 的修復**：本項緩解的是「不讓風險擴大」，**不等於風險已解除**。硬編碼金鑰仍須依 §1.2 缺陷 2 獨立處理（含 revoke & rotate）。
+
+> **殘餘風險**：即使 AC-4～6 全過，`kDebugMode` guard 的正確性仍依賴人為紀律。未來新增接線點時可能漏包。**本次不建 CI 防護（§4.2）**，此判斷的前提是接線點只有四個且集中在兩個檔案；若日後接線點增加，應重新評估。
+
+### 5.2 🟡 R-2：新增傳遞相依帶來的相容性風險
+
+**風險內容**
+
+套件會引入額外相依。**2026-08-05 複驗 `pubspec.yaml` 與 `pubspec.lock` 後，實際狀況比 brainstorm §2.0 的預估樂觀**：
+
+| 相依 | 套件需求 | 本專案現況（複驗） | 判定 |
+| :--- | :--- | :--- | :---: |
+| `dio` | `^5.2.0` | `pubspec.yaml:30` `^5.6.0` | 🟢 相容 |
+| Dart SDK | — | `pubspec.yaml:11` `>=3.5.0 <4.0.0` | 🟢 相容 |
+| `flutter_local_notifications` | `^22.0.0` | `pubspec.yaml:65` **已直接安裝 `^22.1.0`** | 🟢 已存在且版本相容（brainstorm §2.0 記為「未安裝」，**應更正**） |
+| `web` | `^1.1.0` | `pubspec.lock` 已存在（既有傳遞相依） | 🟢 已存在 |
+| `share_plus` | `^13.0.0` | 未安裝 | 🟡 **唯一真正新增的相依** |
+
+**緩解手段**
+
+* 實際只新增 `share_plus` 一個相依，風險面遠小於原估的三個。
+* `flutter_local_notifications` 已是直接相依且主版本相同（22.x），版本衝突風險低；若 `pub get` 仍解不開，該衝突會在 STAGE 0b 的第一步就暴露，屬**早期可見的失敗**。
+* AC-7／AC-8（analyze 零警告、測試全綠）作為相依引入後的即時回歸信號。
+
+### 5.3 🟢 R-3：Debug build 效能受影響
+
+**風險內容**：攔截與記錄本身有開銷，可能讓 debug 下的操作感覺變慢，干擾對效能問題的主觀判斷。
+
+**緩解手段**：效能量測本就應在 **profile 模式**進行（§6.7 既有驗證規範已如此要求），profile 模式不啟用 `kDebugMode` 分支，不受影響。**不需額外處理。**
+
+### 5.4 🟢 R-4：套件本身的穩定性
+
+**風險內容**：第三方套件可能有 bug 或影響宿主 App。
+
+**緩解手段**：套件設計為「錯誤鉤子鏈接（chain）而非覆蓋（override）」，不劫持宿主的錯誤處理；且所有接線位於 `kDebugMode` 內，**release 使用者零暴露**。最壞情況是 debug 體驗受影響，不影響任何產品行為。若確實不堪用，**移除成本等同於 revert 一個小 PR**。
+
+---
+
+## 6. 成功判準 (Definition of Done)
+
+本功能完成的定義是：
+
+1. §3 全部 10 條驗收條件通過，其中 **AC-4～6 為不可妥協項**。
+2. 開發者能在 debug build 中，用一個手勢看到 Yelp 請求的真實耗時——即 **DS-1 可被實際執行**。
+3. Release build 的行為、外觀與 bundle 內容，與整合前無可觀測差異。
+
+**不包含**：任何 §1.2 缺陷的修復。那些是本功能交付之後才開始的工作，也正是本功能存在的目的。
+
+---
+
+## 7. 後續銜接 (Follow-up)
+
+本功能交付後，下列項目應**優先**排入，因為它們的驗證能力剛剛才建立起來：
+
+| 後續項目 | 本功能提供的量測能力 |
+| :--- | :--- |
+| §1.2 缺陷 5：移除假延遲 | Network 分頁可讀出真實 round-trip；移除後若閃爍，timeline 可定位被掩蓋的 race condition |
+| §1.2 缺陷 2：硬編碼金鑰 | 可實地確認 header 中的 `authToken` 是否已改由 broker 供給 |
+| §1.2 缺陷 7：Marker 未連動 | Navigator 分頁 + Console 對照，確認 rebuild 是否真的觸發 |
+| §6.7 S2／S3 視覺改造 | 診斷報告一鍵匯出，回報視覺問題時附得上網路與導航 timeline |
+
+---
+
+## 附錄 A：參考資訊
+
+**套件**：[`flutter_inspector_kit`](https://pub.dev/packages/flutter_inspector_kit)
+
+* 版本：`1.9.0`（2026-08-05 時的 pub.dev 最新版）
+* 授權：MIT
+* 平台：Android／iOS／Web／Windows／macOS／Linux
+* 能力：console log、網路請求攔截（含 replay）、導航追蹤、資料庫監控、診斷報告匯出
+
+**套件公開 API 形貌**（取自套件官方文件，**非本專案的整合方式**——實際接線由 STAGE 0b 決定）：
+
+```dart
+final inspector = FlutterInspector(slowRequestThreshold: const Duration(seconds: 3));
+
+MaterialApp(
+  navigatorObservers: [inspector.navigatorObserver],
+  builder: (context, child) => FlutterInspectorMagicalTap(
+    onTap: () => inspector.openDashboard(context),
+    child: child ?? const SizedBox.shrink(),
+  ),
+);
+
+dio.interceptors.add(FlutterInspectorDioInterceptor(inspector, sourceDio: dio));
+```
+
+> 此範例僅供理解套件 API 長相。本專案為 `PlatformApp` 而非 `MaterialApp`、DI 走 GetIt、Dio 建立於 `DioClient`，**實際整合形式與 `kDebugMode` 的包法留給 STAGE 0b 實作計畫**。
+
+---
+
+## 附錄 B：複驗紀錄 (Re-verification Log — 2026-08-05)
+
+| 事項 | brainstorm §2.0 原記載 | 本次複驗結果 |
+| :--- | :--- | :--- |
+| 硬編碼金鑰行號 | `constants.dart:30,40` | `:30`（`staticMapApiKey`）、**`:41`**（`authToken`，原記 `:40` 應更正） |
+| Dio 掛載點 | `dio_client.dart:24,29` | ✅ 一致 |
+| `PlatformApp` | `main.dart:51` | ✅ 一致，且目前未使用 `navigatorObservers` |
+| `builder:` 層 | `main.dart:79` | ✅ 一致（`:79-82`，回傳 `Theme(...)`） |
+| DI 機制 | GetIt，非 injectable | ✅ 一致（`lib/di/injection.dart`，12 個 `registerLazySingleton`） |
+| 新增傳遞相依 | 3 個（`flutter_local_notifications`、`share_plus`、`web`）皆未安裝 | ⚠️ **應更正為 1 個**：`flutter_local_notifications ^22.1.0` 已直接安裝於 `pubspec.yaml:65`、`web` 已存在於 `pubspec.lock`，**僅 `share_plus` 為新增** |

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -1,0 +1,462 @@
+# F-0.1 — 整合 `flutter_inspector_kit` · 實作計畫
+
+> STAGE 0b：How（資料結構、檔案異動、任務拆分）
+> 規格來源：`docs/features/2026-08-05-flutter-inspector-kit-integration.md`（§4 範圍與 §3 AC 已由使用者拍板，本計畫不推翻）
+> 撰寫日期：2026-08-05
+> 基準 commit：`2890610`（branch `main`）
+> 基準線實測：`flutter analyze` → `No issues found!`（已複驗）
+
+---
+
+## 0. 規格勘誤（實作前必讀）
+
+實地複驗程式碼與 pub.dev metadata 後，發現規格書兩處記載與現況不符。**兩處都會直接改變實作方式**，故列在最前面。
+
+### 0.1 🔴 勘誤 A：Dart SDK 下界不相容（規格 §5.2 記為「🟢 相容」，實為需修改）
+
+`flutter_inspector_kit 1.9.0` 的 pubspec（pub.dev API 實測）：
+
+```yaml
+environment:
+  sdk: "^3.10.1"      # 即 >=3.10.1 <4.0.0
+  flutter: ">=3.10.0"
+```
+
+本專案 `pubspec.yaml:11` 為 `sdk: '>=3.5.0 <4.0.0'`。下界 `3.5.0 < 3.10.1`，**`flutter pub get` 會直接解不開**。
+
+**緩解成本為零**：`pubspec.lock` 現已解析為 `dart: ">=3.11.0 <4.0.0"`，代表既有傳遞相依早已要求 3.11+，`3.5.0` 這個下界只是沒人維護的過時宣告。本機環境 Dart 3.11.5 / Flutter 3.41.9，滿足所有條件。
+
+**處置**：T1 一併把 `pubspec.yaml:11` 提升為 `sdk: '>=3.10.1 <4.0.0'`。這是**追認既成事實**，非擴大範圍。
+
+### 0.2 🔴 勘誤 B：Dio 接線點不在 `dio_client.dart`，而在 `api_clz.dart:42`
+
+規格 §1.3 接線點 2 記為「`dio_client.dart:24`、`:29` 已有掛載點，沿用即可」。實測後這個判斷**不成立**：
+
+| 事實 | 位置 | 後果 |
+| :--- | :--- | :--- |
+| `DioClient` 是**泛用容器**，不知道自己被誰用 | `lib/api/dio/dio_client.dart:4-35` | 在此硬塞 inspector 等於讓通用類別依賴 debug 工具，是錯的抽象層 |
+| 實際被 DI 註冊的 `dioClient` 是 `api_clz.dart:42` 的**頂層 `final`** | `lib/api/api_clz.dart:42-54` | `injection.dart:12` 只是 `() => dioClient`，**沒有建立 Dio 的權力**；DI 層不是接線點 |
+| `interceptWraps` 型別是 `List<InterceptorsWrapper>?` | `dio_client.dart:11` | `FlutterInspectorDioInterceptor extends Interceptor`（實測套件原始碼），**不是** `InterceptorsWrapper`，型別不符，無法從既有參數傳入 |
+| 既有 auth header 由 `InterceptorsWrapper` 在 `api_clz.dart:46-53` 注入 | 同上 | inspector 必須排在**它之後**才錄得到真實 header（DS-2 / AC-2 的核心訴求） |
+
+**處置**：接線改在 `api_clz.dart:42` 的 `dioClient` 初始化式旁，於 `dioClient` 建立**後**追加一行 `dio.interceptors.add(...)`。`dio_client.dart` **完全不動**——這反而更貼合規格 §4.2「不寫包裝抽象層」的原則。
+
+> **這不是擴大範圍**：接線點數量仍是 4 個，只是其中一個的實際座標與規格書的記載不同。規格 §4.1 的四件事一件不多一件不少。
+
+---
+
+## 1. 實作策略總覽
+
+**一句話**：加 1 個相依、提 1 行 SDK 下界、在 4 個既有位置各加一段 `kDebugMode` 分支，然後花力氣證明 release 裡什麼都沒有。
+
+**核心資料結構**：一個 `FlutterInspector?` 型別的**頂層可空變數**，debug 時為實例、release 時恆為 `null`。全專案只有這一個持有點。
+
+```
+T1 相依與 SDK ─→ T2 inspector 持有點 ─┬─→ T3 Dio 接線 ────┐
+   (pubspec)        (inspector.dart)   │   (api_clz.dart)  ├─→ T5 靜態驗證 ─→ T6 release 硬驗證
+                                       └─→ T4 App 接線 ────┘     (AC-7/8/10)     (AC-4/5/6/9)
+                                           (main.dart)
+```
+
+**並行性**：T3（`lib/api/api_clz.dart`）與 T4（`lib/main.dart`）寫入路徑完全不重疊，**可完全並行**。T1 → T2 → {T3, T4} 為強制序列（T3/T4 都要 import T2 產出的符號；T2 要 import T1 引入的套件）。T5 必須等 T3/T4 都完成。T6 是人工驗證，必須最後做。
+
+---
+
+## 2. 設計判斷
+
+### 2.1 🔴 `kDebugMode` 的包法：**單一 nullable 持有點 + 呼叫端 null 檢查**
+
+規格 §3.2 把這題列為 STAGE 0b 待決事項。三個候選：
+
+| 方案 | 作法 | 判定 |
+| :--- | :--- | :---: |
+| **A. no-op stub** | 定義 `abstract class Inspector`，debug 註冊真實實作、release 註冊空實作 | ❌ |
+| **B. 每個呼叫端各包 `if (kDebugMode)`**，各自 `FlutterInspector()` | 四處各建一個實例 | ❌ |
+| **C. 單一頂層 `FlutterInspector?`，debug 賦值、release 為 `null`** | 呼叫端用 `?.` / null 檢查 | ✅ **採用** |
+
+**否決 A 的理由**：規格 §4.2 明文「單一實作的抽象層是純負債」。而且 stub 方案**做不到 AC-6**——release 若仍註冊一個 stub，`FlutterInspector` 這個型別名仍可能被 interface 的型別宣告牽連進 bundle。抽象層在這裡不只是多餘，是**反效果**。
+
+**否決 B 的理由**：`FlutterInspector` 內部持有 buffer（實測建構子有 `bufferSize: 500` 與 `InspectorRegistry`）。四個實例代表 Dio 錄到的請求跟 Navigator 錄到的導航**進不了同一個 dashboard**，AC-2 與 AC-3 會同時失敗。這是設計錯誤，不只是浪費。
+
+**採用 C 的具體結構**（新檔 `lib/di/inspector.dart`）：
+
+```dart
+// 形狀示意，非最終程式碼
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+
+/// Debug-only 除錯工具實例。release build 中恆為 `null`，
+/// 所有引用點因此成為 dead code 而被 tree-shaking 移除。
+final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;
+```
+
+**為什麼這樣就能達成 tree-shaking（AC-6）**：`kDebugMode` 是 `const bool`，Dart AOT 編譯器在 release 下把 `kDebugMode ? X : null` 常數摺疊為 `null`，`FlutterInspector(...)` 建構呼叫成為不可達程式碼；沒有任何地方構造該型別，其 `openDashboard` → `DashboardModal.show` 的整條 UI 呼叫鏈全部失去進入點，被 tree-shaker 摘除。
+
+**為什麼不放 GetIt**：GetIt 是**執行期**註冊表，`getIt<T>()` 以 `Type` 為鍵做動態查表——這正好是 tree-shaker **無法**證明不可達的模式，等於親手保留 dashboard 符號，直接威脅 AC-6。頂層 `final` 是編譯期可見的，這裡「不用 DI」比「用 DI」更正確。同時也避免動到 `test/di_test.dart` 的斷言集合。
+
+> **`ponytail:`** 一個頂層可空變數 + 三個 null 檢查，取代抽象層/工廠/DI 註冊。這是能同時滿足 AC-2、AC-3、AC-6 的最短結構。
+
+### 2.2 為什麼呼叫端仍要**顯式** `if (kDebugMode)`（而非只靠 `?.`）
+
+規格 §5.1 緩解手段 1 明訂「四個接線點無一例外必須位於 `kDebugMode` 判斷之內」。單靠 `inspector != null` 在語意上等價，但：
+
+1. **可審閱性**：AC-5 的驗證方式是「檢視 release 路徑的接線是否全數位於 `kDebugMode` 判斷之內」。`grep kDebugMode` 要能一次撈出全部四處，這是驗收動作本身的需求。
+2. **抵禦未來的漏包**（§5.1 殘餘風險）：日後有人把 `inspector` 誤改為非空，`if (kDebugMode)` 仍是第二道防線。
+
+**結論**：`main.dart` 的兩處接線用 `if (kDebugMode)` 明寫；`api_clz.dart` 因為在頂層初始化式中，同樣以 `if (kDebugMode)` 起手。四處 grep 得到，零例外。
+
+### 2.3 建構子參數的取捨：**幾乎全用預設值**
+
+實測套件建構子有 13 個參數。規格 §4.2 明文「先用套件預設值」。逐項判定：
+
+| 參數 | 預設 | 決定 | 理由 |
+| :--- | :--- | :--- | :--- |
+| `slowRequestThreshold` | `2s` | **顯式設 `2s`** | DS-1 要證明「2 秒假延遲是多餘的」。閾值恰好對齊該數字，讓超標請求一眼可見。雖與預設同值，顯式寫出是**意圖宣告** |
+| `redactSensitiveData` | `true` | **不動（沿用 `true`）** | 直接呼應 §5.1 R-1。即便真的漏進 release，第二道防線仍在 |
+| `showNetworkNotification` | `false` | **不動** | 設 `true` 會觸發 `flutter_local_notifications` 的權限請求，是可見的行為改變，違反 AC-9 |
+| `navigatorKey` | `null` | **不動** | 僅服務 notification tap，上一項已關閉 |
+| `captureUncaughtErrors` | `false` | **不動** | 規格 §5.4 的安心前提正是「不劫持宿主錯誤處理」。設 `true` 會去動 `FlutterError.onError`，是 AC-9 的風險 |
+| `captureLifecycleEvents` | `false` | **不動** | §2 五個故事沒有一個需要它 |
+| `magicalTapCount` | `5` | **不動** | 5 連點的誤觸機率已足夠低 |
+| 其餘（`customTab` 等） | — | **不動** | 無需求 |
+
+> **只設一個參數**。每多設一個都是在「改造溫度計」（規格 §4.3）。
+
+### 2.4 Dio 攔截器的**插入順序**
+
+`api_clz.dart:45-54` 的 `interceptWraps` 注入 `Authorization` header。dio 的 `onRequest` 依 `interceptors` 順序執行，因此：
+
+```
+LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
+  → InterceptorsWrapper (注入 Authorization)      ← api_clz.dart:46
+    → FlutterInspectorDioInterceptor              ← 必須在這個位置
+```
+
+若排在 auth wrapper **之前**，錄到的 `requestHeaders` 會缺少 `Authorization`，**DS-2 與 AC-2 直接失敗**。由於 `DioClient` 建構子內部先 `.add(LogInterceptor)` 再 `.addAll(interceptWraps)`，只要在 `dioClient` **建構完成後**追加 `.add(...)`，順序自然正確——這也是勘誤 B 選擇「建構後追加」而非「傳參進去」的另一個理由。
+
+`sourceDio:` 參數傳 `dioClient.dio`（實測簽章 `FlutterInspectorDioInterceptor(this._inspector, {this.sourceDio})`，用途為 request replay）。
+
+### 2.5 `main.dart` 的兩處接線形狀
+
+- **`navigatorObservers`**：`PlatformApp` 目前未使用此參數（實測 `main.dart:51-82` 確認）。新增 `navigatorObservers: kDebugMode && inspector != null ? [inspector!.navigatorObserver] : const []`。
+  > **`!` 的正當性**：專案 style guide 禁止無法證明非空的 `!`。此處 `inspector != null` 已在同一表達式中證明，屬 Dart 型別提升可接受範圍；但為徹底避免 lint 摩擦，**優先採用區域變數提升**寫法（見 T4 描述）。
+- **喚起手勢**：既有 `builder:` 回傳 `Theme(data:..., child: child ?? const SizedBox.shrink())`。改為在 debug 時把 `Theme(...)` **再包一層** `FlutterInspectorMagicalTap`。實測其簽章為 `FlutterInspectorMagicalTap({required this.child, required this.onTap, this.tapCount = 5, this.timeout = ...})`——`child` 與 `onTap` 皆為 **required named**。內部是 `GestureDetector(behavior: HitTestBehavior.translucent)`，不吃掉子樹的點擊事件，對 AC-9 無影響。
+
+  順序必須是 `MagicalTap` 在**外**、`Theme` 在**內**：`onTap` 回呼需要的 `context` 來自 `builder` 的第一個參數（目前是 `_`，需改名為 `context`），而 dashboard 需要能找到 `Navigator`——`builder` 的 context 位於 `Navigator` 之下，可用。
+
+---
+
+## 3. 檔案異動清單
+
+| # | 檔案 | 位置 | 動作 |
+| :---: | :--- | :--- | :--- |
+| 1 | `pubspec.yaml` | `:11` | `sdk: '>=3.5.0 <4.0.0'` → `'>=3.10.1 <4.0.0'`（勘誤 A） |
+| 2 | `pubspec.yaml` | `dependencies:` 末段（`crypto: ^3.0.3` 之後，`# Standard Flutter SDK` 註解之前，約 `:71-72`） | 新增註解區塊 `# 開發除錯工具 (Developer Tooling — debug only)` + `flutter_inspector_kit: ^1.9.0` |
+| 3 | **`lib/di/inspector.dart`**（新檔） | — | 頂層 `final FlutterInspector? inspector = kDebugMode ? FlutterInspector(slowRequestThreshold: const Duration(seconds: 2)) : null;` + doc comment |
+| 4 | `lib/di/di_barrel.dart` | `:1` 之後 | 新增 `export 'inspector.dart';` |
+| 5 | `lib/api/api_clz.dart` | import 區、`:42-55` 之間 | `dioClient` 建立後、`apiInstance` 建立前，插入 `kDebugMode` 分支呼叫 `dioClient.dio.interceptors.add(FlutterInspectorDioInterceptor(inspector!, sourceDio: dioClient.dio))` 的等價安全寫法 |
+| 6 | `lib/main.dart` | `:52` 附近（`navigatorKey:` 之後） | 新增 `navigatorObservers:` 參數 |
+| 7 | `lib/main.dart` | `:79-82` `builder:` | `_` → `context`，debug 時外包 `FlutterInspectorMagicalTap` |
+
+**不動的檔案**（明確聲明，避免 implementer 誤觸）：
+- ❌ `lib/api/dio/dio_client.dart` — 勘誤 B 已說明理由，`LogInterceptor` 一併保留（規格 §4.2）
+- ❌ `lib/di/injection.dart` — §2.1 已說明不走 GetIt
+- ❌ `test/` 下任何檔案 — 規格 §4.2「不為 inspector 本身寫測試」
+- ❌ `lib/features/foundation/constants/constants.dart` — 規格 §4.2「不順便修既有缺陷」
+
+**平台設定**：`share_plus`（唯一新增傳遞相依）在 iOS/Android 上為純 Dart + 標準 platform channel，**無需**手動改 `AndroidManifest.xml` 或 `Info.plist`。若 `flutter build` 報缺設定，才依錯誤訊息處理（屬 T6 的例外處置，不預先做）。
+
+---
+
+## 4. 任務拆分
+
+> 複雜度分級依 `gen-dev-workflow` STAGE 2 判準：
+> **快/便宜** = 觸及 1-2 檔案且規格完整、機械性 ｜ **標準** = 觸及多檔需整合協調 ｜ **最強推論** = 需設計判斷或廣泛理解
+
+### T1 — 引入相依並提升 SDK 下界
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | `pubspec.yaml`（+ 產出的 `pubspec.lock`） |
+| **複雜度** | 🟢 **快/便宜** |
+| **對應 AC** | 前置（R-2 的早期失敗信號） |
+| **並行性** | 無法並行，所有任務的前置 |
+
+**動作**：
+1. `pubspec.yaml:11` → `sdk: '>=3.10.1 <4.0.0'`
+2. `crypto: ^3.0.3`（`:71`）之後新增：
+   ```yaml
+   # 開發除錯工具 (Developer Tooling — debug only)
+   flutter_inspector_kit: ^1.9.0 # App 內除錯儀表板 (網路/導航/日誌)，全數以 kDebugMode 圍住
+   ```
+   > 放 `dependencies:` 而非 `dev_dependencies:` 是**必要**的：`dev_dependencies` 不會被打包進 app，`lib/` 下的程式碼無法 import。安全性由 `kDebugMode` + tree-shaking 保證（§2.1），不靠相依區塊分類。
+
+**驗收**：`flutter pub get` 成功結束；`pubspec.lock` 出現 `flutter_inspector_kit` 與 `share_plus`。
+**失敗處置**：若版本解不開，**立即停下回報**，不要自行放寬其他套件版本（R-2 的早期可見失敗）。
+
+---
+
+### T2 — 建立 inspector 唯一持有點
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | `lib/di/inspector.dart`（新）、`lib/di/di_barrel.dart` |
+| **複雜度** | 🟢 **快/便宜**（設計判斷已在本計畫 §2.1/§2.3 定案，實作為機械性） |
+| **對應 AC** | AC-5、AC-6（結構性前提）、AC-7、AC-10 |
+| **並行性** | 依賴 T1；為 T3/T4 的前置 |
+
+**動作**：新建 `lib/di/inspector.dart`，內容為 §2.1 的形狀，`slowRequestThreshold` 依 §2.3 顯式設為 `const Duration(seconds: 2)`，其餘參數全用預設。加繁體中文 doc comment 說明「release 恆為 null」與該設計的 tree-shaking 理由。於 `di_barrel.dart` 加一行 export。
+
+**驗收**：`flutter analyze` 零警告。
+
+---
+
+### T3 — Dio 攔截器接線
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | `lib/api/api_clz.dart` |
+| **複雜度** | 🟡 **標準**（單一檔案，但需正確處理頂層初始化順序與攔截器排序，見 §2.4） |
+| **對應 AC** | AC-2、AC-5 |
+| **並行性** | ✅ **可與 T4 完全並行**（寫入路徑不重疊） |
+
+**動作**：在 `api_clz.dart` 的 `dioClient`（`:42`）與 `apiInstance`（`:55`）之間，用「先取得已建構的 dio、再條件式追加攔截器」的方式接線。因頂層 `final` 不能放語句，採用 IIFE 形式的初始化式（與 `dio_client.dart:12`、`:20` 專案既有慣例一致）或把攔截器追加移入既有的 `dioClient` 初始化鏈——**由 implementer 擇一，但必須滿足**：
+
+1. inspector 攔截器排在 auth `InterceptorsWrapper` **之後**（§2.4）
+2. 整段以 `if (kDebugMode)` 圍住，`grep kDebugMode lib/api/api_clz.dart` 撈得到
+3. `apiInstance` 建立時攔截器已就位（`apiInstance` 引用 `dioClient.dio`，兩者共用同一 `Dio`，順序不影響正確性，但避免 lazy 初始化順序陷阱：確保追加動作屬於 `dioClient` 的初始化式而非獨立頂層語句）
+4. 不使用未經證明的 `!`（用區域變數提升）
+
+**驗收**：`flutter analyze` 零警告；T6 中 AC-2 實跑通過。
+
+---
+
+### T4 — `PlatformApp` 接線（observer + 喚起手勢）
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | `lib/main.dart` |
+| **複雜度** | 🟡 **標準**（兩處接線 + `PlatformApp` 跨平台雙分支語意 + null-safety 寫法約束） |
+| **對應 AC** | AC-1、AC-3、AC-4、AC-5、AC-9 |
+| **並行性** | ✅ **可與 T3 完全並行** |
+
+**動作**：
+1. import 區加 `package:flutter/foundation.dart`（取 `kDebugMode`）。`di/di_barrel.dart` 已在 `:10` import，`inspector` 隨 T2 的 export 自動可見，**不需新增 import**。
+   > 注意：`main.dart:4` 已 import `package:flutter/material.dart`，它**不會**傳遞出 `kDebugMode`（`kDebugMode` 在 `foundation.dart`，而 `material.dart` 確實 re-export `foundation.dart`）。實作時若 analyze 報 unused import 則移除該行——以 analyze 結果為準，不預設。
+2. `navigatorKey:`（`:52`）之後加 `navigatorObservers:`，debug 且非 null 時給 `[inspector.navigatorObserver]`，否則 `const []`。
+3. `builder:`（`:79`）的 `_` 改為 `context`；回傳值在 debug 時外包 `FlutterInspectorMagicalTap(onTap: () => inspector.openDashboard(context), child: Theme(...))`，release 維持原本的 `Theme(...)`。**`Theme` 必須在內層**（§2.5）。
+
+**寫法約束**：為避免 `!` 與重複條件，建議先在 `build` 內取 `final ins = kDebugMode ? inspector : null;` 做型別提升，後續用 `ins == null ? 原樣 : 包一層`。
+
+**驗收**：`flutter analyze` 零警告；T6 中 AC-1/AC-3 實跑通過；Android 與 iOS 兩個分支外觀皆無變化（AC-9）。
+
+---
+
+### T5 — 靜態驗證
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | 無（唯讀 + 可能的格式化） |
+| **複雜度** | 🟢 **快/便宜** |
+| **對應 AC** | AC-7、AC-8、AC-10，以及 AC-5 的程式碼審閱部分 |
+| **並行性** | 必須等 T3 與 T4 皆完成 |
+
+**動作**：執行 §5.1 的全部指令，任一不過即退回對應任務。
+
+---
+
+### T6 — Release 硬驗證（🔴 不可妥協）
+
+| 項目 | 內容 |
+| :--- | :--- |
+| **觸及檔案** | 無（build 產物） |
+| **複雜度** | 🔴 **最強推論**（需判讀 build 產物、判斷符號殘留是否為真陽性、評估行為差異） |
+| **對應 AC** | **AC-4、AC-5、AC-6**（硬性）+ AC-9 |
+| **並行性** | 最後執行，不可並行 |
+
+**動作**：執行 §5.2 的全部步驟。**任一不過 → 不得合併**（規格 §3.2）。
+
+---
+
+## 5. 驗證步驟
+
+### 5.1 靜態驗證（T5）
+
+```bash
+# AC-10 — 格式（範圍限定本功能異動檔案，避免把 base branch 既有格式化落差一併掃入 diff）
+dart format --set-exit-if-changed lib/di/inspector.dart lib/di/di_barrel.dart lib/api/api_clz.dart lib/main.dart
+
+# AC-7 — 靜態分析必須維持 "No issues found!"（基準線已實測為零警告）
+rtk flutter analyze
+
+# AC-8 — 既有 14 個測試檔全綠
+rtk flutter test
+
+# AC-5（程式碼審閱面）— 四個接線點必須全部 grep 得到 kDebugMode
+rtk proxy grep -rn "kDebugMode" lib/di/inspector.dart lib/api/api_clz.dart lib/main.dart
+# 預期：inspector.dart 1 處、api_clz.dart 1 處、main.dart 2 處（observer + builder）
+# 少於 4 處 → 有接線點漏包，退回 T3/T4
+```
+
+### 5.2 Release 硬驗證（T6）
+
+#### AC-6 — Tree-shaking 驗證（本計畫決定的具體指令）
+
+Flutter release 的 Dart 程式碼編譯為 AOT 機器碼，**符號名不會以純文字保留**，直接 `strings` 掃 `.so` 不可靠（會有偽陰性）。採用**兩層驗證**：
+
+**第一層（主要證據）— 對照 Dart AOT 的符號輸出**
+
+```bash
+# Android：產出 release APK 並輸出編譯後的符號地圖
+rtk flutter build apk --release --split-debug-info=build/symbols-release
+
+# 檢查 dashboard 的核心類別是否出現在符號地圖中
+rtk proxy grep -ri "DashboardModal\|FlutterInspectorDashboard\|InspectorOverlayManager" build/symbols-release/ | head
+# 預期：無輸出（0 筆）→ AC-6 通過
+```
+
+**第二層（對照組，證明檢測方法本身有效）**
+
+```bash
+# 對 debug 產物做同一檢查，必須「找得到」，否則代表上面的 grep 根本是無效檢查
+rtk flutter build apk --debug
+rtk proxy grep -ric "DashboardModal" build/app/intermediates/ 2>/dev/null | head
+```
+
+> **這一層不能省。** 一個永遠回傳 0 筆的檢查等於沒有檢查——AC-6 的價值取決於檢測方法被證明有辨識力。
+
+**第三層（bundle 體積佐證）**
+
+```bash
+rtk flutter build apk --release --analyze-size --target-platform=android-arm64
+# 於輸出中確認 flutter_inspector_kit 的 package 佔比。預期：不出現，或僅剩極小的 model 類別殘留
+```
+
+若第三層顯示 `flutter_inspector_kit` 佔用可觀體積，代表 tree-shaking **未生效**，須回頭檢查 §2.1 的 nullable 結構是否被破壞（最常見原因：有人把 `inspector` 改成非空、或把它塞進 GetIt/Map 等動態容器）。
+
+**iOS 對應指令**（Android 通過後執行，兩平台皆須通過）：
+
+```bash
+rtk flutter build ios --release --no-codesign --split-debug-info=build/symbols-release-ios
+rtk proxy grep -ri "DashboardModal\|InspectorOverlayManager" build/symbols-release-ios/ | head
+```
+
+#### AC-4 — Release 無進入點（🔴 必須實機驗證，不接受程式碼審閱）
+
+```bash
+rtk flutter install --release        # 或 flutter run --release 於實機
+```
+
+實機操作清單（逐項確認**無任何反應**）：
+
+| # | 畫面 | 動作 | 預期 |
+| :---: | :--- | :--- | :--- |
+| 1 | 主列表 | 空白處 5 連點 | 無反應 |
+| 2 | 餐廳詳情 | 空白處 5 連點 | 無反應 |
+| 3 | 最愛 | 空白處 5 連點 | 無反應 |
+| 4 | 設定 | 空白處 5 連點 | 無反應 |
+| 5 | 任一畫面 | 全畫面掃視 | 無 FAB、無 overlay、無任何 debug 入口 |
+
+#### AC-5 — Release 不註冊攔截器 / observer
+
+由 §5.1 的 `grep kDebugMode` 四處齊全 + AC-4 實機無反應 + AC-6 符號不存在，三者共同構成證據。**不額外做**（規格 §4.2 排除 CI 自動化）。
+
+#### AC-9 — Release 行為與外觀不變
+
+同一台實機，整合前（`git stash` 或 `2890610` 的 build）與整合後的 release build，逐一比對：
+
+| 流程 | 檢查點 |
+| :--- | :--- |
+| 餐廳搜尋 | 結果列表內容、載入時間主觀無差異 |
+| 篩選 | 篩選標籤互動、結果更新 |
+| 餐廳詳情 | 圖片、評論、地圖顯示 |
+| 最愛 | 加入/移除、跨啟動持久化 |
+| 訪客模式 | 登入引導行為 |
+| 導航 | 全流程頁面切換無異常（**`navigatorObservers` 是唯一動到框架層的接線，重點觀察**） |
+| 廣告 | Banner 正常顯示 |
+
+#### AC-1 / AC-2 / AC-3 — Debug 功能驗證
+
+```bash
+rtk flutter run --debug
+```
+
+| AC | 步驟 | 通過標準 |
+| :--- | :--- | :--- |
+| AC-1 | 任一畫面空白處 5 連點 | dashboard modal 開啟 |
+| AC-2 | 執行一次餐廳搜尋 → Network 分頁 | 找到 `/v3/businesses/search` 該筆，含 URL、method、狀態碼、**耗時**、request/response body，且 **request headers 含 `Authorization`**（驗證 §2.4 的攔截器順序正確；若被 `redactSensitiveData` 遮蔽為遮罩值，視為通過——欄位存在即滿足 DS-2） |
+| AC-3 | 列表 → 詳情 → 返回 → Navigator 分頁 | 三筆導航事件（push / push / pop）齊全 |
+
+---
+
+## 6. 風險對應（規格 §5 → 實作落實）
+
+### R-1 🔴 Inspector 進入 release（最大風險）
+
+| 規格緩解手段 | 本計畫的具體落實 |
+| :--- | :--- |
+| `kDebugMode` guard 為強制設計約束 | **雙層**：①`lib/di/inspector.dart` 的 `kDebugMode ? ... : null` 讓 release 中實例根本不存在（§2.1）；②三個呼叫端各自顯式 `if (kDebugMode)`（§2.2）。任一層單獨即足夠，兩層同時失效才會出事 |
+| 拒絕 GetIt 註冊 | §2.1 明確否決。GetIt 的 `Type`→`Object` 動態查表會阻止 tree-shaker 證明不可達，是 AC-6 的直接威脅 |
+| 拒絕抽象層 / stub | §2.1 否決方案 A。單一實作的 interface 不只是負債，還會讓型別宣告把 dashboard 牽連進 bundle |
+| AC-4～6 為合併前必過項 | T6 為獨立任務且標為不可妥協；§5.2 給出可執行指令 |
+| 實機驗證非程式碼審閱 | §5.2 AC-4 的 5 項實機清單，明列「不接受程式碼審閱」 |
+| 不因此延後缺陷 2 | 本計畫**不碰** `constants.dart`（§3 不動檔案清單）。硬編碼金鑰仍是獨立待辦，本功能不宣稱已緩解 |
+
+**殘餘風險的實作層對應**：§5.1 提到「未來新增接線點可能漏包」。本計畫的 §5.1 驗證加入 `grep -rn kDebugMode` **並明列預期筆數為 4**——新增接線點時筆數不符會立刻暴露。這是零成本的紀律錨點，不違反 §4.2「不建 CI 自動化」。
+
+### R-2 🟡 相依相容性
+
+- **T1 為第一個任務且獨立驗收**：`flutter pub get` 失敗即刻停下，屬規格所稱「早期可見的失敗」。
+- **勘誤 A 已把最可能的失敗點前移**：SDK 下界不合已在計畫階段查出，T1 一併處理，不會在實作中途才炸。
+- `flutter_local_notifications ^22.1.0` 已是直接相依且主版本相同；`web` 已在 lock；唯一新增為 `share_plus`。
+- AC-7 / AC-8 作為引入後的即時回歸信號（T5）。
+
+### R-3 🟢 Debug 效能
+
+**不做任何處理**（規格 §5.3 結論）。效能量測在 profile 模式進行，`kDebugMode` 為 `false`，`inspector` 為 `null`，不受影響。此處僅記錄：實作時**不得**因「怕慢」而加任何開關或設定——那是規格 §4.2 排除的「長期治理」。
+
+### R-4 🟢 套件穩定性
+
+- §2.3 明確**不開啟** `captureUncaughtErrors`，保證套件完全不觸碰宿主的 `FlutterError.onError` / `PlatformDispatcher.onError` / `ErrorWidget.builder`。這把規格 §5.4 的「chain 而非 override」進一步強化為「連 chain 都不做」。
+- §2.3 **不開啟** `showNetworkNotification`，避免 `flutter_local_notifications` 的權限提示污染 AC-9。
+- 移除成本：本計畫的異動集中在 1 個新檔 + 3 個既有檔的小段落，revert 成本等同一個小 PR（符合規格 §5.4 的預期）。
+
+---
+
+## 7. 執行方式選項
+
+本計畫可用兩種方式推進，**建議 A**：
+
+### A. Subagent-driven（建議）
+
+單一 session，由 orchestrator 依序派發：
+
+```
+T1 (快/便宜) → T2 (快/便宜) → [T3 標準 ∥ T4 標準] → T5 (快/便宜) → T6 (最強推論)
+```
+
+- T3 與 T4 派給兩個並行 subagent（寫入路徑不重疊，無衝突風險）
+- T6 需要人在場操作實機，orchestrator 在此**暫停**待人工回報
+- **優點**：T1/T2 的相依與符號定義由同一上下文產出，T3/T4 拿到的是確定的 API 形狀，不會各自猜測
+- **適用**：本任務總體積小（4 個檔案、約 30 行淨增），開 parallel session 的協調成本高於收益
+
+### B. Parallel session
+
+T3 與 T4 各開一個 session。**前提**：T1 + T2 必須已在 main 上完成並 commit，否則兩個 session 會各自對 `inspector` 的形狀做出不同假設。
+
+- **適用**：若 T3 的 dio 頂層初始化寫法需要較長探索（§4 T3 的四項約束），與 T4 分離可避免互相等待
+- **代價**：需要一次額外的 commit 同步點
+
+**兩種方式都不改變**：T6 必須最後、單獨、由人工在實機執行。
+
+---
+
+## 8. 完成定義
+
+對齊規格 §6：
+
+1. ✅ AC-1～10 全數通過，其中 **AC-4～6 為不可妥協項**
+2. ✅ DS-1 可實際執行：debug build 中 5 連點 → Network 分頁讀出 Yelp 搜尋的真實 round-trip 毫秒數
+3. ✅ Release build 的行為、外觀與 bundle 內容與 `2890610` 無可觀測差異
+
+**不包含**：任何 §1.2 缺陷的修復。溫度計裝好就該去量體溫（規格 §4.3）。

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -112,7 +112,7 @@ final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;
 | 參數 | 預設 | 決定 | 理由 |
 | :--- | :--- | :--- | :--- |
 | `slowRequestThreshold` | `2s` | **顯式設 `2s`** | DS-1 要證明「2 秒假延遲是多餘的」。閾值恰好對齊該數字，讓超標請求一眼可見。雖與預設同值，顯式寫出是**意圖宣告** |
-| `redactSensitiveData` | `true` | **改為 `false`** | 使用者要求 debug 時 Network 分頁完整顯示敏感欄位，不遮蔽，方便除錯核對真實 request/response。整個建構子仍在 `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9；§5.1 R-1 的「第二道防線」因此收斂為單靠 `kDebugMode` guard，殘餘風險見下方新增說明 |
+| `redactSensitiveData` | `true` | **改為 `false`（2026-08-05 二次修訂：更正理由）** | ~~原理由「debug 時 Network 分頁完整顯示敏感欄位，不遮蔽」不成立~~：實測套件原始碼（`network_detail_view.dart:66`）確認**畫面顯示從未受此旗標影響**，headers 一律原樣顯示。此旗標唯一作用的是**匯出/分享/複製到剪貼簿**路徑（`buildCurl`／`buildPlainText`／`export_report_sheet.dart` 的 `redact:` 參數）。使用者已知悉此範圍後仍要求 `false`：**確實需要匯出/分享診斷報告時也不遮蔽敏感欄位**，是明確的知情決定，非除錯畫面需求。整個建構子仍在 `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9；§5.1 R-1 的「第二道防線」因此收斂為單靠 `kDebugMode` guard，殘餘風險見下方新增說明 |
 | `showNetworkNotification` | `false` | **改為 `true`** | 使用者要求 debug 時網路請求跳系統通知。僅在 `kDebugMode` 分支內生效，release 不受影響，AC-9 不成立的風險僅限「debug build 需要通知權限」，不涉及 release 行為 |
 | `navigatorKey` | `null` | **改為傳入 `main.dart` 既有的 `navigatorKey`** | 未設定時 `showNetworkNotification` 的 tap-to-open 為 no-op（套件 `_openNetworkFromNotification` 對 `null` context 直接返回）。既然通知已開啟（見上一列），點通知應能實際開啟 dashboard，故沿用 app 既有的 `GlobalKey<NavigatorState>`（`lib/main.dart:21`，已是 `PlatformApp.navigatorKey`），`lib/di/inspector.dart` 以 `import '../main.dart' show navigatorKey;` 取得，不新增第二把 key |
 | `captureUncaughtErrors` | `false` | **改為 `true`** | 使用者要求 debug 時攔截未捕捉例外。已查證套件原始碼（`uncaught_error_handler.dart`）：`FlutterError.onError`／`PlatformDispatcher.onError`／`ErrorWidget.builder` 三處皆為 **chain/wrap**、非 override——記錄後接續呼叫原有 handler。且本專案未設定任何全域 error handler，無衝突可能。規格 §5.4「不劫持宿主錯誤處理」的安心前提由套件的 chain 機制保證，非規則本身禁止開啟 |
@@ -122,7 +122,7 @@ final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;
 
 > **範圍仍受 `kDebugMode` 單一分支界定**：四項改動全部發生在 `FlutterInspector(...)` 建構子內部，該建構子本身只在 `kDebugMode == true` 時才會被求值（見 §2.1），release 恆為 `null`。因此本次修訂不影響 AC-4／AC-6／AC-9 的 release 安全性，僅改變 debug build 的除錯資訊豐富度。
 >
-> **殘餘風險更新**：`redactSensitiveData: false` 拿掉了「即便漏進 release 仍有遮蔽」這道第二防線，現在完全依賴 `kDebugMode` guard 這唯一一層。此風險與 §6 R-1 的既有殘餘風險描述（「未來新增接線點可能漏包」）性質相同，緩解手段不變：T5 的 `grep kDebugMode` 四處齊全檢查、T6 的實機硬驗證。
+> **殘餘風險更新**：`redactSensitiveData: false` 拿掉的是「匯出/分享/剪貼簿路徑即便漏進 release 仍遮蔽」這道防線（畫面顯示本就不受此旗標影響，見上表更正後的理由），現在完全依賴 `kDebugMode` guard 這唯一一層。此風險與 §6 R-1 的既有殘餘風險描述（「未來新增接線點可能漏包」）性質相同，緩解手段不變：T5 的 `grep kDebugMode` 接線點齊全檢查、T6 的實機硬驗證。額外殘餘風險：即使 `kDebugMode` guard 正常運作，debug build 中使用者若把匯出的診斷報告（含未遮蔽的 `Authorization` 等敏感欄位）分享到外部管道（issue、聊天工具），內容本身仍是明碼——這是使用者已知情並接受的取捨，非本功能的安全缺陷。
 
 ### 2.4 Dio 攔截器的**插入順序**
 

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -105,22 +105,24 @@ final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;
 
 **結論**：`main.dart` 的兩處接線用 `if (kDebugMode)` 明寫；`api_clz.dart` 因為在頂層初始化式中，同樣以 `if (kDebugMode)` 起手。四處 grep 得到，零例外。
 
-### 2.3 建構子參數的取捨：**幾乎全用預設值**
+### 2.3 建構子參數的取捨（2026-08-05 修訂：使用者明確要求開啟四項 debug 專屬功能）
 
-實測套件建構子有 13 個參數。規格 §4.2 明文「先用套件預設值」。逐項判定：
+實測套件建構子有 13 個參數。規格 §4.2 明文「先用套件預設值」，原始判定為「幾乎全用預設值」；使用者事後複查要求開啟 `showNetworkNotification`／`captureUncaughtErrors`／`captureLifecycleEvents` 並關閉 `redactSensitiveData`，逐項改判如下：
 
 | 參數 | 預設 | 決定 | 理由 |
 | :--- | :--- | :--- | :--- |
 | `slowRequestThreshold` | `2s` | **顯式設 `2s`** | DS-1 要證明「2 秒假延遲是多餘的」。閾值恰好對齊該數字，讓超標請求一眼可見。雖與預設同值，顯式寫出是**意圖宣告** |
-| `redactSensitiveData` | `true` | **不動（沿用 `true`）** | 直接呼應 §5.1 R-1。即便真的漏進 release，第二道防線仍在 |
-| `showNetworkNotification` | `false` | **不動** | 設 `true` 會觸發 `flutter_local_notifications` 的權限請求，是可見的行為改變，違反 AC-9 |
-| `navigatorKey` | `null` | **不動** | 僅服務 notification tap，上一項已關閉 |
-| `captureUncaughtErrors` | `false` | **不動** | 規格 §5.4 的安心前提正是「不劫持宿主錯誤處理」。設 `true` 會去動 `FlutterError.onError`，是 AC-9 的風險 |
-| `captureLifecycleEvents` | `false` | **不動** | §2 五個故事沒有一個需要它 |
+| `redactSensitiveData` | `true` | **改為 `false`** | 使用者要求 debug 時 Network 分頁完整顯示敏感欄位，不遮蔽，方便除錯核對真實 request/response。整個建構子仍在 `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9；§5.1 R-1 的「第二道防線」因此收斂為單靠 `kDebugMode` guard，殘餘風險見下方新增說明 |
+| `showNetworkNotification` | `false` | **改為 `true`** | 使用者要求 debug 時網路請求跳系統通知。僅在 `kDebugMode` 分支內生效，release 不受影響，AC-9 不成立的風險僅限「debug build 需要通知權限」，不涉及 release 行為 |
+| `navigatorKey` | `null` | **不動** | 未設定 `navigatorKey` 時 `showNetworkNotification` 的 tap-to-open 為 no-op（套件 `_openNetworkFromNotification` 對 `null` context 直接返回），不影響核心功能；如需點通知直接開啟 dashboard，可後續再補 |
+| `captureUncaughtErrors` | `false` | **改為 `true`** | 使用者要求 debug 時攔截未捕捉例外。已查證套件原始碼（`uncaught_error_handler.dart`）：`FlutterError.onError`／`PlatformDispatcher.onError`／`ErrorWidget.builder` 三處皆為 **chain/wrap**、非 override——記錄後接續呼叫原有 handler。且本專案未設定任何全域 error handler，無衝突可能。規格 §5.4「不劫持宿主錯誤處理」的安心前提由套件的 chain 機制保證，非規則本身禁止開啟 |
+| `captureLifecycleEvents` | `false` | **改為 `true`** | 使用者要求 debug 時記錄生命週期事件。套件用 `WidgetsBinding.addObserver`，本就支援多 observer 並存，不影響既有生命週期邏輯 |
 | `magicalTapCount` | `5` | **不動** | 5 連點的誤觸機率已足夠低 |
 | 其餘（`customTab` 等） | — | **不動** | 無需求 |
 
-> **只設一個參數**。每多設一個都是在「改造溫度計」（規格 §4.3）。
+> **範圍仍受 `kDebugMode` 單一分支界定**：四項改動全部發生在 `FlutterInspector(...)` 建構子內部，該建構子本身只在 `kDebugMode == true` 時才會被求值（見 §2.1），release 恆為 `null`。因此本次修訂不影響 AC-4／AC-6／AC-9 的 release 安全性，僅改變 debug build 的除錯資訊豐富度。
+>
+> **殘餘風險更新**：`redactSensitiveData: false` 拿掉了「即便漏進 release 仍有遮蔽」這道第二防線，現在完全依賴 `kDebugMode` guard 這唯一一層。此風險與 §6 R-1 的既有殘餘風險描述（「未來新增接線點可能漏包」）性質相同，緩解手段不變：T5 的 `grep kDebugMode` 四處齊全檢查、T6 的實機硬驗證。
 
 ### 2.4 Dio 攔截器的**插入順序**
 

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -114,7 +114,7 @@ final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;
 | `slowRequestThreshold` | `2s` | **顯式設 `2s`** | DS-1 要證明「2 秒假延遲是多餘的」。閾值恰好對齊該數字，讓超標請求一眼可見。雖與預設同值，顯式寫出是**意圖宣告** |
 | `redactSensitiveData` | `true` | **改為 `false`** | 使用者要求 debug 時 Network 分頁完整顯示敏感欄位，不遮蔽，方便除錯核對真實 request/response。整個建構子仍在 `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9；§5.1 R-1 的「第二道防線」因此收斂為單靠 `kDebugMode` guard，殘餘風險見下方新增說明 |
 | `showNetworkNotification` | `false` | **改為 `true`** | 使用者要求 debug 時網路請求跳系統通知。僅在 `kDebugMode` 分支內生效，release 不受影響，AC-9 不成立的風險僅限「debug build 需要通知權限」，不涉及 release 行為 |
-| `navigatorKey` | `null` | **不動** | 未設定 `navigatorKey` 時 `showNetworkNotification` 的 tap-to-open 為 no-op（套件 `_openNetworkFromNotification` 對 `null` context 直接返回），不影響核心功能；如需點通知直接開啟 dashboard，可後續再補 |
+| `navigatorKey` | `null` | **改為傳入 `main.dart` 既有的 `navigatorKey`** | 未設定時 `showNetworkNotification` 的 tap-to-open 為 no-op（套件 `_openNetworkFromNotification` 對 `null` context 直接返回）。既然通知已開啟（見上一列），點通知應能實際開啟 dashboard，故沿用 app 既有的 `GlobalKey<NavigatorState>`（`lib/main.dart:21`，已是 `PlatformApp.navigatorKey`），`lib/di/inspector.dart` 以 `import '../main.dart' show navigatorKey;` 取得，不新增第二把 key |
 | `captureUncaughtErrors` | `false` | **改為 `true`** | 使用者要求 debug 時攔截未捕捉例外。已查證套件原始碼（`uncaught_error_handler.dart`）：`FlutterError.onError`／`PlatformDispatcher.onError`／`ErrorWidget.builder` 三處皆為 **chain/wrap**、非 override——記錄後接續呼叫原有 handler。且本專案未設定任何全域 error handler，無衝突可能。規格 §5.4「不劫持宿主錯誤處理」的安心前提由套件的 chain 機制保證，非規則本身禁止開啟 |
 | `captureLifecycleEvents` | `false` | **改為 `true`** | 使用者要求 debug 時記錄生命週期事件。套件用 `WidgetsBinding.addObserver`，本就支援多 observer 並存，不影響既有生命週期邏輯 |
 | `magicalTapCount` | `5` | **不動** | 5 連點的誤觸機率已足夠低 |

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -146,7 +146,7 @@ LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
 
   **🔴 已修正的錯誤判斷（原文保留刪除線以留紀錄）**：~~`onTap` 回呼需要的 `context` 來自 `builder` 的第一個參數，而 dashboard 需要能找到 `Navigator`——`builder` 的 context 位於 `Navigator` 之下，可用。~~ 此判斷**錯誤**：`PlatformApp.builder` 的 `context` 語意上位於 `Navigator` **之上**（`builder` 存在的目的正是包裹整個 Navigator 樹的外殼），`openDashboard` 內部呼叫 `showGeneralDialog(context: context, ...)` 需要往上解析 `NavigatorState`，用這個 context 會在每次觸發時丟 `Navigator operation requested with a context that does not include a Navigator` assertion error。**實際修法**：改用 `navigatorKey.currentContext`（`NavigatorState` 自身的 context，位於 `Navigator` 之下）取代 `builder` 傳入的外層 `context`。
 
-- **常駐 FAB（2026-08-05 新增，與五連點並存）**：套件另提供 `FlutterInspector.attach({required BuildContext context, bool visible = true})`，把可拖曳的 `InspectorFab` 插入最近的 `Overlay`。這是**命令式** API（非 declarative widget），且同樣需要位於 `Overlay`（隨 `Navigator` 建立）之下的 context，與喚起手勢踩到同一個「`builder` context 位置不對」的坑。`FindingRestaruantApp` 是 `StatelessWidget`，沒有 `initState` 可用，改在 `main()` 的 `runApp(...)` 之後用 `WidgetsBinding.instance.addPostFrameCallback` 等第一幀畫完（此時 `Navigator`／`Overlay` 已掛載），取 `navigatorKey.currentContext` 呼叫一次 `inspector.attach(context: navContext)`。呼叫本身冪等（`_overlayEntry != null` 時 no-op），不需要 `detach()`——app 存活期間 FAB 常駐是預期行為。
+- **常駐 FAB（2026-08-05 新增，與五連點並存；2026-08-05 修訂接線位置）**：套件另提供 `FlutterInspector.attach({required BuildContext context, bool visible = true})`，把可拖曳的 `InspectorFab` 插入最近的 `Overlay`。這是**命令式** API（非 declarative widget），且同樣需要位於 `Overlay`（隨 `Navigator` 建立）之下的 context，與喚起手勢踩到同一個「`builder` context 位置不對」的坑。原始版本放在 `main()` 的 `runApp(...)` 之後用 `navigatorKey.currentContext`；**改為放在 `lib/flow/splash/view/splash_page.dart` 的 `_SplashPageState.initState()` 既有 `addPostFrameCallback` 回呼的最後**——`SplashPage` 本身是 `routes` 表掛載的路由 widget，其 `build(context)` 的 `context` 天生位於 `Navigator`/`Overlay` 之下，比 `navigatorKey.currentContext`（時序上更早、依賴 key 是否已附著）更直接可靠，且該頁面本就有 `addPostFrameCallback` 可複用，不需在 `main.dart` 額外起一個回呼。呼叫本身冪等（`_overlayEntry != null` 時 no-op），不需要 `detach()`——app 存活期間 FAB 常駐是預期行為。
 
 ---
 
@@ -161,7 +161,7 @@ LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
 | 5 | `lib/api/api_clz.dart` | import 區、`:42-55` 之間 | `dioClient` 建立後、`apiInstance` 建立前，插入 `kDebugMode` 分支呼叫 `dioClient.dio.interceptors.add(FlutterInspectorDioInterceptor(inspector!, sourceDio: dioClient.dio))` 的等價安全寫法 |
 | 6 | `lib/main.dart` | `:52` 附近（`navigatorKey:` 之後） | 新增 `navigatorObservers:` 參數 |
 | 7 | `lib/main.dart` | `:79-82` `builder:` | `_` → `context`，debug 時外包 `FlutterInspectorMagicalTap`；`onTap` 用 `navigatorKey.currentContext`（非 `builder` 傳入的 `context`，見 §2.5 已修正的錯誤判斷） |
-| 8 | `lib/main.dart`（2026-08-05 新增） | `main()` 內 `runApp(...)` 之後 | `addPostFrameCallback` 呼叫一次 `inspector.attach(context: navigatorKey.currentContext)`，掛上常駐 FAB（見 §2.5） |
+| 8 | `lib/flow/splash/view/splash_page.dart`（2026-08-05 新增） | `_SplashPageState.initState()` 既有 `addPostFrameCallback` 回呼最後 | `inspector.attach(context: context)`，掛上常駐 FAB；`context` 為 `SplashPage` 自身、已在 Navigator/Overlay 之下（見 §2.5） |
 
 **不動的檔案**（明確聲明，避免 implementer 誤觸）：
 - ❌ `lib/api/dio/dio_client.dart` — 勘誤 B 已說明理由，`LogInterceptor` 一併保留（規格 §4.2）

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -167,6 +167,7 @@ LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
 - ❌ `lib/api/dio/dio_client.dart` — 勘誤 B 已說明理由，`LogInterceptor` 一併保留（規格 §4.2）
 - ❌ `lib/di/injection.dart` — §2.1 已說明不走 GetIt
 - ❌ `test/` 下任何檔案 — 規格 §4.2「不為 inspector 本身寫測試」
+  > **唯一例外（2026-08-05）**：`test/app_theme_platform_test.dart` 因 `captureUncaughtErrors: true`（§2.3）在該測試 mount 真實 `FindingRestaruantApp` 時觸發 `inspector` 首次求值，連帶把全域 `ErrorWidget.builder` 等 hook 換掉，導致 `flutter_test` 的逐測試 before/after 驗證判定失敗。修法是在該測試 callback 結尾復原三個全域 hook——這是**修復被本功能打壞的既有測試**，不是「為 inspector 本身寫新測試」，不違反本條禁令的原始意圖。
 - ❌ `lib/features/foundation/constants/constants.dart` — 規格 §4.2「不順便修既有缺陷」
 
 **平台設定**：`share_plus`（唯一新增傳遞相依）在 iOS/Android 上為純 Dart + 標準 platform channel，**無需**手動改 `AndroidManifest.xml` 或 `Info.plist`。若 `flutter build` 報缺設定，才依錯誤訊息處理（屬 T6 的例外處置，不預先做）。

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -138,13 +138,15 @@ LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
 
 `sourceDio:` 參數傳 `dioClient.dio`（實測簽章 `FlutterInspectorDioInterceptor(this._inspector, {this.sourceDio})`，用途為 request replay）。
 
-### 2.5 `main.dart` 的兩處接線形狀
+### 2.5 `main.dart` 的接線形狀
 
 - **`navigatorObservers`**：`PlatformApp` 目前未使用此參數（實測 `main.dart:51-82` 確認）。新增 `navigatorObservers: kDebugMode && inspector != null ? [inspector!.navigatorObserver] : const []`。
   > **`!` 的正當性**：專案 style guide 禁止無法證明非空的 `!`。此處 `inspector != null` 已在同一表達式中證明，屬 Dart 型別提升可接受範圍；但為徹底避免 lint 摩擦，**優先採用區域變數提升**寫法（見 T4 描述）。
 - **喚起手勢**：既有 `builder:` 回傳 `Theme(data:..., child: child ?? const SizedBox.shrink())`。改為在 debug 時把 `Theme(...)` **再包一層** `FlutterInspectorMagicalTap`。實測其簽章為 `FlutterInspectorMagicalTap({required this.child, required this.onTap, this.tapCount = 5, this.timeout = ...})`——`child` 與 `onTap` 皆為 **required named**。內部是 `GestureDetector(behavior: HitTestBehavior.translucent)`，不吃掉子樹的點擊事件，對 AC-9 無影響。
 
-  順序必須是 `MagicalTap` 在**外**、`Theme` 在**內**：`onTap` 回呼需要的 `context` 來自 `builder` 的第一個參數（目前是 `_`，需改名為 `context`），而 dashboard 需要能找到 `Navigator`——`builder` 的 context 位於 `Navigator` 之下，可用。
+  **🔴 已修正的錯誤判斷（原文保留刪除線以留紀錄）**：~~`onTap` 回呼需要的 `context` 來自 `builder` 的第一個參數，而 dashboard 需要能找到 `Navigator`——`builder` 的 context 位於 `Navigator` 之下，可用。~~ 此判斷**錯誤**：`PlatformApp.builder` 的 `context` 語意上位於 `Navigator` **之上**（`builder` 存在的目的正是包裹整個 Navigator 樹的外殼），`openDashboard` 內部呼叫 `showGeneralDialog(context: context, ...)` 需要往上解析 `NavigatorState`，用這個 context 會在每次觸發時丟 `Navigator operation requested with a context that does not include a Navigator` assertion error。**實際修法**：改用 `navigatorKey.currentContext`（`NavigatorState` 自身的 context，位於 `Navigator` 之下）取代 `builder` 傳入的外層 `context`。
+
+- **常駐 FAB（2026-08-05 新增，與五連點並存）**：套件另提供 `FlutterInspector.attach({required BuildContext context, bool visible = true})`，把可拖曳的 `InspectorFab` 插入最近的 `Overlay`。這是**命令式** API（非 declarative widget），且同樣需要位於 `Overlay`（隨 `Navigator` 建立）之下的 context，與喚起手勢踩到同一個「`builder` context 位置不對」的坑。`FindingRestaruantApp` 是 `StatelessWidget`，沒有 `initState` 可用，改在 `main()` 的 `runApp(...)` 之後用 `WidgetsBinding.instance.addPostFrameCallback` 等第一幀畫完（此時 `Navigator`／`Overlay` 已掛載），取 `navigatorKey.currentContext` 呼叫一次 `inspector.attach(context: navContext)`。呼叫本身冪等（`_overlayEntry != null` 時 no-op），不需要 `detach()`——app 存活期間 FAB 常駐是預期行為。
 
 ---
 
@@ -158,7 +160,8 @@ LogInterceptor (dio_client.dart:24, isLogEnabled 預設 true)
 | 4 | `lib/di/di_barrel.dart` | `:1` 之後 | 新增 `export 'inspector.dart';` |
 | 5 | `lib/api/api_clz.dart` | import 區、`:42-55` 之間 | `dioClient` 建立後、`apiInstance` 建立前，插入 `kDebugMode` 分支呼叫 `dioClient.dio.interceptors.add(FlutterInspectorDioInterceptor(inspector!, sourceDio: dioClient.dio))` 的等價安全寫法 |
 | 6 | `lib/main.dart` | `:52` 附近（`navigatorKey:` 之後） | 新增 `navigatorObservers:` 參數 |
-| 7 | `lib/main.dart` | `:79-82` `builder:` | `_` → `context`，debug 時外包 `FlutterInspectorMagicalTap` |
+| 7 | `lib/main.dart` | `:79-82` `builder:` | `_` → `context`，debug 時外包 `FlutterInspectorMagicalTap`；`onTap` 用 `navigatorKey.currentContext`（非 `builder` 傳入的 `context`，見 §2.5 已修正的錯誤判斷） |
+| 8 | `lib/main.dart`（2026-08-05 新增） | `main()` 內 `runApp(...)` 之後 | `addPostFrameCallback` 呼叫一次 `inspector.attach(context: navigatorKey.currentContext)`，掛上常駐 FAB（見 §2.5） |
 
 **不動的檔案**（明確聲明，避免 implementer 誤觸）：
 - ❌ `lib/api/dio/dio_client.dart` — 勘誤 B 已說明理由，`LogInterceptor` 一併保留（規格 §4.2）

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -297,10 +297,12 @@ rtk flutter analyze
 # AC-8 — 既有 14 個測試檔全綠
 rtk flutter test
 
-# AC-5（程式碼審閱面）— 四個接線點必須全部 grep 得到 kDebugMode
-rtk proxy grep -rn "kDebugMode" lib/di/inspector.dart lib/api/api_clz.dart lib/main.dart
-# 預期：inspector.dart 1 處、api_clz.dart 1 處、main.dart 2 處（observer + builder）
-# 少於 4 處 → 有接線點漏包，退回 T3/T4
+# AC-5（程式碼審閱面）— 五個接線點必須全部 grep 得到 kDebugMode
+# （2026-08-05 修訂：新增 FAB 進入點後由 4 處增為 5 處，見 §2.5）
+rtk proxy grep -rn "kDebugMode" lib/di/inspector.dart lib/api/api_clz.dart lib/main.dart lib/flow/splash/view/splash_page.dart
+# 預期：inspector.dart 1 處、api_clz.dart 1 處、main.dart 2 處（observer + builder）、
+#       splash_page.dart 1 處（FAB attach）
+# 少於 5 處 → 有接線點漏包，退回對應任務
 ```
 
 ### 5.2 Release 硬驗證（T6）

--- a/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
+++ b/flutter_restaruant/flutter_restaruant/docs/plans/2026-08-05-flutter-inspector-kit-integration.md
@@ -423,11 +423,11 @@ rtk flutter run --debug
 
 **不做任何處理**（規格 §5.3 結論）。效能量測在 profile 模式進行，`kDebugMode` 為 `false`，`inspector` 為 `null`，不受影響。此處僅記錄：實作時**不得**因「怕慢」而加任何開關或設定——那是規格 §4.2 排除的「長期治理」。
 
-### R-4 🟢 套件穩定性
+### R-4 🟢 套件穩定性（2026-08-05 更新：`captureUncaughtErrors`／`showNetworkNotification` 決定已變更）
 
-- §2.3 明確**不開啟** `captureUncaughtErrors`，保證套件完全不觸碰宿主的 `FlutterError.onError` / `PlatformDispatcher.onError` / `ErrorWidget.builder`。這把規格 §5.4 的「chain 而非 override」進一步強化為「連 chain 都不做」。
-- §2.3 **不開啟** `showNetworkNotification`，避免 `flutter_local_notifications` 的權限提示污染 AC-9。
-- 移除成本：本計畫的異動集中在 1 個新檔 + 3 個既有檔的小段落，revert 成本等同一個小 PR（符合規格 §5.4 的預期）。
+- ~~§2.3 明確不開啟 `captureUncaughtErrors`，保證套件完全不觸碰宿主的 handler~~：此段已過時。§2.3 二次修訂後**改為開啟** `captureUncaughtErrors: true`。套件內部經查證（`uncaught_error_handler.dart`）對 `FlutterError.onError`／`PlatformDispatcher.onError`／`ErrorWidget.builder` 三者皆為 chain/wrap、非 override，原有錯誤處理不會被覆蓋，符合規格 §5.4「chain 而非 override」的安心前提。唯一實際副作用：`flutter_test` 會偵測到 `ErrorWidget.builder` 在測試期間被改動而判定失敗，已於 `test/app_theme_platform_test.dart` 以 `try/finally` 復原全域 hook 修復（見 §3 檔案異動清單的 test 例外說明）。
+- ~~§2.3 不開啟 `showNetworkNotification`，避免權限提示污染 AC-9~~：此段已過時。§2.3 二次修訂後**改為開啟** `showNetworkNotification: true`，debug build 首次啟動會跳系統通知權限對話框；此行為僅發生在 `kDebugMode` 分支內，不影響 release 的 AC-9。
+- 移除成本：本計畫的異動集中在 1 個新檔 + 4 個既有檔（`api_clz.dart`／`main.dart`／`splash_page.dart`／`app_theme_platform_test.dart`）的小段落，revert 成本仍等同一個小 PR（符合規格 §5.4 的預期）。
 
 ---
 

--- a/flutter_restaruant/flutter_restaruant/lib/api/api_clz.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/api/api_clz.dart
@@ -1,9 +1,13 @@
-import 'dio/dio_barrel.dart';
-import '../data_layer/dto/dto_barrel.dart';
-import '../features/foundation/constants/constants_barrel.dart';
+import 'package:dio/dio.dart' hide Headers;
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 import 'package:logger/logger.dart';
 import 'package:retrofit/retrofit.dart';
-import 'package:dio/dio.dart' hide Headers;
+
+import '../data_layer/dto/dto_barrel.dart';
+import '../di/di_barrel.dart';
+import '../features/foundation/constants/constants_barrel.dart';
+import 'dio/dio_barrel.dart';
 
 part 'api_clz.g.dart';
 
@@ -14,43 +18,61 @@ abstract class APIClz {
   @POST('/oauth2/token')
   @FormUrlEncoded()
   Future<String> fetchToken(
-      @Field('grant_type') String? grantType,
-      @Field('client_id') String? clientId,
-      @Field('client_secret') String? clientSecret);
+    @Field('grant_type') String? grantType,
+    @Field('client_id') String? clientId,
+    @Field('client_secret') String? clientSecret,
+  );
 
   @GET('/v3/businesses/search')
-  Future<YelpSearchDto> businessesSearch(
-      {@Query('term') String? term,
-      @Query('latitude') double? latitude,
-      @Query('longitude') double? longitude,
-      @Query('locale') String? locale,
-      @Query('limit') int? limit,
-      @Query('offset') int? offset,
-      @Query('open_at') int? openAt,
-      @Query('sort_by') String? sortBy,
-      @Query('price') int? price});
+  Future<YelpSearchDto> businessesSearch({
+    @Query('term') String? term,
+    @Query('latitude') double? latitude,
+    @Query('longitude') double? longitude,
+    @Query('locale') String? locale,
+    @Query('limit') int? limit,
+    @Query('offset') int? offset,
+    @Query('open_at') int? openAt,
+    @Query('sort_by') String? sortBy,
+    @Query('price') int? price,
+  });
 
   @GET('/v3/businesses/{id}')
   Future<YelpRestaurantDetailDto> business(
-      @Path() String? id, @Query('locale') String? locale);
+    @Path() String? id,
+    @Query('locale') String? locale,
+  );
 
   @GET('/v3/businesses/{id}/reviews')
   Future<YelpReviewDto> review(
-      @Path() String? id, @Query('locale') String? locale);
+    @Path() String? id,
+    @Query('locale') String? locale,
+  );
 }
 
-final dioClient = DioClient(
+final dioClient = () {
+  final client = DioClient(
     connectionTimeout: Constants.connectionTimeout,
     receiveTimeout: Constants.receiveTimeout,
     interceptWraps: [
-      InterceptorsWrapper(onRequest: (options, handler) async {
-        var customHeaders = {
-          'Content-Type': 'application/json',
-          'Authorization': Constants.authToken
-        };
-        options.headers.addAll(customHeaders);
-        handler.next(options);
-      })
-    ]);
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          var customHeaders = {
+            'Content-Type': 'application/json',
+            'Authorization': Constants.authToken,
+          };
+          options.headers.addAll(customHeaders);
+          handler.next(options);
+        },
+      ),
+    ],
+  );
+  final insp = inspector;
+  if (kDebugMode && insp != null) {
+    client.dio.interceptors.add(
+      FlutterInspectorDioInterceptor(insp, sourceDio: client.dio),
+    );
+  }
+  return client;
+}();
 final apiInstance = APIClz(dioClient.dio);
 final logger = Logger();

--- a/flutter_restaruant/flutter_restaruant/lib/di/di_barrel.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/di/di_barrel.dart
@@ -1,1 +1,2 @@
 export 'injection.dart';
+export 'inspector.dart';

--- a/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
@@ -3,6 +3,19 @@ import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 
 /// Debug-only 除錯工具實例。release build 中恆為 `null`，
 /// 所有引用點因此成為 dead code 而被 tree-shaking 移除。
+///
+/// 以下參數皆為使用者明確要求開啟的 debug-only 行為，整個建構子都在
+/// `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9：
+/// - `showNetworkNotification`：debug 時網路請求跳系統通知
+/// - `captureUncaughtErrors`：debug 時攔截未捕捉例外
+/// - `captureLifecycleEvents`：debug 時記錄生命週期事件
+/// - `redactSensitiveData: false`：debug 時 Network 分頁不遮蔽敏感欄位
 final FlutterInspector? inspector = kDebugMode
-    ? FlutterInspector(slowRequestThreshold: const Duration(seconds: 2))
+    ? FlutterInspector(
+        slowRequestThreshold: const Duration(seconds: 2),
+        showNetworkNotification: true,
+        captureUncaughtErrors: true,
+        captureLifecycleEvents: true,
+        redactSensitiveData: false,
+      )
     : null;

--- a/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
+
+/// Debug-only 除錯工具實例。release build 中恆為 `null`，
+/// 所有引用點因此成為 dead code 而被 tree-shaking 移除。
+final FlutterInspector? inspector = kDebugMode
+    ? FlutterInspector(slowRequestThreshold: const Duration(seconds: 2))
+    : null;

--- a/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 
+import '../main.dart' show navigatorKey;
+
 /// Debug-only 除錯工具實例。release build 中恆為 `null`，
 /// 所有引用點因此成為 dead code 而被 tree-shaking 移除。
 ///
 /// 以下參數皆為使用者明確要求開啟的 debug-only 行為，整個建構子都在
 /// `kDebugMode` 分支內，release 恆為 `null`，不影響 AC-9：
 /// - `showNetworkNotification`：debug 時網路請求跳系統通知
+/// - `navigatorKey`：沿用 app 既有的 `navigatorKey`，讓上述通知的
+///   tap-to-open 能實際定位到 `NavigatorState` 開啟 dashboard（未設定時
+///   為 no-op）
 /// - `captureUncaughtErrors`：debug 時攔截未捕捉例外
 /// - `captureLifecycleEvents`：debug 時記錄生命週期事件
 /// - `redactSensitiveData: false`：debug 時 Network 分頁不遮蔽敏感欄位
@@ -14,6 +19,7 @@ final FlutterInspector? inspector = kDebugMode
     ? FlutterInspector(
         slowRequestThreshold: const Duration(seconds: 2),
         showNetworkNotification: true,
+        navigatorKey: navigatorKey,
         captureUncaughtErrors: true,
         captureLifecycleEvents: true,
         redactSensitiveData: false,

--- a/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/di/inspector.dart
@@ -14,7 +14,8 @@ import '../main.dart' show navigatorKey;
 ///   為 no-op）
 /// - `captureUncaughtErrors`：debug 時攔截未捕捉例外
 /// - `captureLifecycleEvents`：debug 時記錄生命週期事件
-/// - `redactSensitiveData: false`：debug 時 Network 分頁不遮蔽敏感欄位
+/// - `redactSensitiveData: false`：debug 時匯出／分享／複製診斷內容不遮蔽
+///   敏感欄位（畫面顯示本就不受此旗標影響）
 final FlutterInspector? inspector = kDebugMode
     ? FlutterInspector(
         slowRequestThreshold: const Duration(seconds: 2),

--- a/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
@@ -35,7 +35,8 @@ class _SplashPageState extends State<SplashPage> {
       // SplashPage 自身（已在 Navigator/Overlay 之下的路由 widget），
       // 與 main.dart builder 傳入的外層 context 不同，attach() 找得到
       // Overlay。
-      if (kDebugMode) inspector?.attach(context: context);
+      if (!kDebugMode) return;
+      inspector?.attach(context: context);
     });
   }
 

--- a/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
@@ -35,9 +35,7 @@ class _SplashPageState extends State<SplashPage> {
       // SplashPage 自身（已在 Navigator/Overlay 之下的路由 widget），
       // 與 main.dart builder 傳入的外層 context 不同，attach() 找得到
       // Overlay。
-      final ins = kDebugMode ? inspector : null;
-      if (ins == null) return;
-      ins.attach(context: context);
+      if (kDebugMode) inspector?.attach(context: context);
     });
   }
 

--- a/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../../main/view/view_barrel.dart';
 import '../../signinup/view/view_barrel.dart';
+import '../../../di/di_barrel.dart';
 import '../../../manager/manager_barrel.dart';
 
 class SplashPage extends StatefulWidget {
@@ -22,10 +24,20 @@ class _SplashPageState extends State<SplashPage> {
       await Future.delayed(const Duration(seconds: 3));
       if (mounted) {
         // 訪客已在前次啟動選擇跳過登入，直接進主畫面。
-        final String routeName =
-            SignInManager().isGuest ? MainPage.routeName : SignInPage.routeName;
+        final String routeName = SignInManager().isGuest
+            ? MainPage.routeName
+            : SignInPage.routeName;
         // ignore: unawaited_futures
         Navigator.of(context).pushReplacementNamed(routeName);
+      }
+
+      // 與 5 連點喚起手勢並存的第二進入點：常駐 FAB。此 context 來自
+      // SplashPage 自身（已在 Navigator/Overlay 之下的路由 widget），
+      // 與 main.dart builder 傳入的外層 context 不同，attach() 找得到
+      // Overlay。
+      final ins = kDebugMode ? inspector : null;
+      if (ins != null && mounted) {
+        ins.attach(context: context);
       }
     });
   }
@@ -33,11 +45,12 @@ class _SplashPageState extends State<SplashPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Image.asset(
-      'images/launch_image.png',
-      fit: BoxFit.fill,
-      height: MediaQuery.of(context).size.height,
-      width: MediaQuery.of(context).size.width,
-    ));
+      body: Image.asset(
+        'images/launch_image.png',
+        fit: BoxFit.fill,
+        height: MediaQuery.of(context).size.height,
+        width: MediaQuery.of(context).size.width,
+      ),
+    );
   }
 }

--- a/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/flow/splash/view/splash_page.dart
@@ -22,23 +22,22 @@ class _SplashPageState extends State<SplashPage> {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
       // Waiting building is finish and run.
       await Future.delayed(const Duration(seconds: 3));
-      if (mounted) {
-        // 訪客已在前次啟動選擇跳過登入，直接進主畫面。
-        final String routeName = SignInManager().isGuest
-            ? MainPage.routeName
-            : SignInPage.routeName;
-        // ignore: unawaited_futures
-        Navigator.of(context).pushReplacementNamed(routeName);
-      }
+      if (!mounted) return;
+
+      // 訪客已在前次啟動選擇跳過登入，直接進主畫面。
+      final String routeName = SignInManager().isGuest
+          ? MainPage.routeName
+          : SignInPage.routeName;
+      // ignore: unawaited_futures
+      Navigator.of(context).pushReplacementNamed(routeName);
 
       // 與 5 連點喚起手勢並存的第二進入點：常駐 FAB。此 context 來自
       // SplashPage 自身（已在 Navigator/Overlay 之下的路由 widget），
       // 與 main.dart builder 傳入的外層 context 不同，attach() 找得到
       // Overlay。
       final ins = kDebugMode ? inspector : null;
-      if (ins != null && mounted) {
-        ins.attach(context: context);
-      }
+      if (ins == null) return;
+      ins.attach(context: context);
     });
   }
 

--- a/flutter_restaruant/flutter_restaruant/lib/main.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/main.dart
@@ -40,17 +40,6 @@ void main() async {
     FcmManager().init();
 
     runApp(const FindingRestaruantApp());
-
-    // 與 5 連點喚起手勢並存的第二進入點：常駐 FAB。第一幀畫完後
-    // Navigator（連帶 Overlay）已掛載，navigatorKey.currentContext
-    // 才能被 Overlay.maybeOf 解析到。
-    final ins = kDebugMode ? inspector : null;
-    if (ins != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final navContext = navigatorKey.currentContext;
-        if (navContext != null) ins.attach(context: navContext);
-      });
-    }
   });
 }
 

--- a/flutter_restaruant/flutter_restaruant/lib/main.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'features/foundation/constants/constants_barrel.dart';
@@ -14,6 +15,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'manager/manager_barrel.dart';
 import 'routes/routes_barrel.dart';
 import 'features/foundation/style/style_barrel.dart';
+import 'package:flutter_inspector_kit/flutter_inspector_kit.dart';
 
 // For FCM onMessageOpenedApp to open specific page
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -29,9 +31,7 @@ void main() async {
   Future.wait([
     Constants.init(),
     // Firebase Init
-    Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    ),
+    Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
     S.load(ui.PlatformDispatcher.instance.locale),
     // 於 runApp 前載入，使 isGuest 可被 UI 同步查詢
     SignInManager().loadPrefs(),
@@ -49,35 +49,46 @@ class FindingRestaruantApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) => PlatformApp(
-      navigatorKey: navigatorKey,
-      locale: const Locale('zh', 'TW'),
-      localizationsDelegates: const [
-        S.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-      ],
-      supportedLocales: S.delegate.supportedLocales,
-      debugShowCheckedModeBanner: false,
-      title: UIConstants.appTitle,
-      routes: routesTable,
-      // 不做深色模式（darkTheme 指向同一份 light），系統切深色時 app 外觀
-      // 維持不變，避免內容淺色底卻配到深色模式的系統 UI。
-      material: (_, __) => MaterialAppData(
-            theme: AppThemeData.materialLight,
-            darkTheme: AppThemeData.materialLight,
-            themeMode: ThemeMode.light,
-          ),
-      // iOS 走 CupertinoApp 分支，`material:` 不生效。CupertinoApp 自身的
-      // brightness 預設會跟隨 MediaQuery.platformBrightnessOf，導致系統深色
-      // 模式下狀態列圖示轉白、與淺色內容相衝，故在此明確鎖為 light。
-      cupertino: (_, __) => CupertinoAppData(
-            theme: AppThemeData.cupertinoLight,
-          ),
-      // 兩個平台的 Material widget 都靠這層解析到同一份 ThemeData
-      // （iOS 沒有 MaterialApp 可繼承，Android 則是與內層 Theme 重疊但無害）。
-      builder: (_, child) => Theme(
-            data: AppThemeData.materialLight,
-            child: child ?? const SizedBox.shrink(),
-          ));
+    navigatorKey: navigatorKey,
+    navigatorObservers: kDebugMode && inspector != null
+        ? [inspector!.navigatorObserver]
+        : const [],
+    locale: const Locale('zh', 'TW'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+    ],
+    supportedLocales: S.delegate.supportedLocales,
+    debugShowCheckedModeBanner: false,
+    title: UIConstants.appTitle,
+    routes: routesTable,
+    // 不做深色模式（darkTheme 指向同一份 light），系統切深色時 app 外觀
+    // 維持不變，避免內容淺色底卻配到深色模式的系統 UI。
+    material: (_, __) => MaterialAppData(
+      theme: AppThemeData.materialLight,
+      darkTheme: AppThemeData.materialLight,
+      themeMode: ThemeMode.light,
+    ),
+    // iOS 走 CupertinoApp 分支，`material:` 不生效。CupertinoApp 自身的
+    // brightness 預設會跟隨 MediaQuery.platformBrightnessOf，導致系統深色
+    // 模式下狀態列圖示轉白、與淺色內容相衝，故在此明確鎖為 light。
+    cupertino: (_, __) => CupertinoAppData(theme: AppThemeData.cupertinoLight),
+    // 兩個平台的 Material widget 都靠這層解析到同一份 ThemeData
+    // （iOS 沒有 MaterialApp 可繼承，Android 則是與內層 Theme 重疊但無害）。
+    builder: (context, child) {
+      final theme = Theme(
+        data: AppThemeData.materialLight,
+        child: child ?? const SizedBox.shrink(),
+      );
+      final ins = kDebugMode ? inspector : null;
+      return ins == null
+          ? theme
+          : FlutterInspectorMagicalTap(
+              onTap: () => ins.openDashboard(context),
+              child: theme,
+            );
+    },
+  );
 }

--- a/flutter_restaruant/flutter_restaruant/lib/main.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/main.dart
@@ -86,7 +86,14 @@ class FindingRestaruantApp extends StatelessWidget {
       return ins == null
           ? theme
           : FlutterInspectorMagicalTap(
-              onTap: () => ins.openDashboard(context),
+              // `context` here (from PlatformApp.builder) sits above the
+              // Navigator, so showGeneralDialog can't resolve a
+              // NavigatorState from it. navigatorKey.currentContext is the
+              // NavigatorState's own context, which is below the Navigator.
+              onTap: () {
+                final navContext = navigatorKey.currentContext;
+                if (navContext != null) ins.openDashboard(navContext);
+              },
               child: theme,
             );
     },

--- a/flutter_restaruant/flutter_restaruant/lib/main.dart
+++ b/flutter_restaruant/flutter_restaruant/lib/main.dart
@@ -40,6 +40,17 @@ void main() async {
     FcmManager().init();
 
     runApp(const FindingRestaruantApp());
+
+    // 與 5 連點喚起手勢並存的第二進入點：常駐 FAB。第一幀畫完後
+    // Navigator（連帶 Overlay）已掛載，navigatorKey.currentContext
+    // 才能被 Overlay.maybeOf 解析到。
+    final ins = kDebugMode ? inspector : null;
+    if (ins != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final navContext = navigatorKey.currentContext;
+        if (navContext != null) ins.attach(context: navContext);
+      });
+    }
   });
 }
 

--- a/flutter_restaruant/flutter_restaruant/pubspec.lock
+++ b/flutter_restaruant/flutter_restaruant/pubspec.lock
@@ -651,6 +651,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  flutter_inspector_kit:
+    dependency: "direct main"
+    description:
+      name: flutter_inspector_kit
+      sha256: db264ac0a7f38c1508e291fefe67c210f9a3d8c411bd0e7545bfecfa91796ad0
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -1548,6 +1556,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  share_plus:
+    dependency: transitive
+    description:
+      name: share_plus
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.3.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/flutter_restaruant/flutter_restaruant/pubspec.yaml
+++ b/flutter_restaruant/flutter_restaruant/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.4.0+30
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.10.1 <4.0.0'
 
 dependencies:
   # UI 元件與介面元件 (UI Components & Layouts)
@@ -69,6 +69,9 @@ dependencies:
   sprintf: ^7.0.0 # 字串格式化工具
   logger: ^2.4.0 # 多層級日誌紀錄工具 (Logger)
   crypto: ^3.0.3 # 加密與雜湊演算法 (MD5, SHA-256 等)
+
+  # 開發除錯工具 (Developer Tooling — debug only)
+  flutter_inspector_kit: ^1.9.0 # App 內除錯儀表板 (網路/導航/日誌)，全數以 kDebugMode 圍住
 
   # Standard Flutter SDK and core packages
   flutter:

--- a/flutter_restaruant/flutter_restaruant/test/app_theme_platform_test.dart
+++ b/flutter_restaruant/flutter_restaruant/test/app_theme_platform_test.dart
@@ -35,26 +35,31 @@ void main() {
       final originalPlatformDispatcherOnError =
           ui.PlatformDispatcher.instance.onError;
 
-      await tester.pumpWidget(
-        Theme(
-          data: ThemeData(platform: target),
-          child: const FindingRestaruantApp(),
-        ),
-      );
+      // try/finally：測試主體若中途失敗（例如 expect 不通過），仍要復原
+      // 三個全域 hook，避免汙染下一次迭代（Android case）的 before/after
+      // 快照、掩蓋真正的失敗原因。
+      try {
+        await tester.pumpWidget(
+          Theme(
+            data: ThemeData(platform: target),
+            child: const FindingRestaruantApp(),
+          ),
+        );
 
-      // 由 navigatorKey 取得 route 之下的 context，確保讀到的是 app 實際
-      // 套用的 theme，而非測試自建的外層 Theme。
-      final scheme = Theme.of(navigatorKey.currentContext!).colorScheme;
+        // 由 navigatorKey 取得 route 之下的 context，確保讀到的是 app 實際
+        // 套用的 theme，而非測試自建的外層 Theme。
+        final scheme = Theme.of(navigatorKey.currentContext!).colorScheme;
 
-      expect(scheme.primary, AppThemeData.materialLight.colorScheme.primary);
+        expect(scheme.primary, AppThemeData.materialLight.colorScheme.primary);
 
-      // SplashPage 的 3 秒延遲不排掉會留下 pending timer，測試 framework 會報錯。
-      await tester.pump(const Duration(seconds: 3));
-
-      ErrorWidget.builder = originalErrorWidgetBuilder;
-      FlutterError.onError = originalFlutterErrorOnError;
-      ui.PlatformDispatcher.instance.onError =
-          originalPlatformDispatcherOnError;
+        // SplashPage 的 3 秒延遲不排掉會留下 pending timer，測試 framework 會報錯。
+        await tester.pump(const Duration(seconds: 3));
+      } finally {
+        ErrorWidget.builder = originalErrorWidgetBuilder;
+        FlutterError.onError = originalFlutterErrorOnError;
+        ui.PlatformDispatcher.instance.onError =
+            originalPlatformDispatcherOnError;
+      }
     });
   }
 }

--- a/flutter_restaruant/flutter_restaruant/test/app_theme_platform_test.dart
+++ b/flutter_restaruant/flutter_restaruant/test/app_theme_platform_test.dart
@@ -1,3 +1,4 @@
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_restaruant/di/di_barrel.dart';
@@ -20,10 +21,26 @@ void main() {
 
   for (final target in [TargetPlatform.iOS, TargetPlatform.android]) {
     testWidgets('AppThemeData 在 $target 上可被解析', (tester) async {
-      await tester.pumpWidget(Theme(
-        data: ThemeData(platform: target),
-        child: const FindingRestaruantApp(),
-      ));
+      // lib/di/inspector.dart 的 captureUncaughtErrors: true 會在
+      // FlutterInspector 建構子內立刻 attach 三個全域 error hook
+      // （FlutterError.onError／PlatformDispatcher.onError／
+      // ErrorWidget.builder）。`inspector` 是頂層 lazy final，全專案
+      // 只有本測試會 mount 真實 FindingRestaruantApp，故首次求值必在
+      // 此發生。flutter_test 對每個測試各自比對 pumpWidget 前後的
+      // ErrorWidget.builder，變動會被判定失敗——package:test 的
+      // tearDown() 在此驗證之後才執行，太晚救不了，必須在本 callback
+      // 結尾、pumpWidget 之後手動復原。
+      final originalErrorWidgetBuilder = ErrorWidget.builder;
+      final originalFlutterErrorOnError = FlutterError.onError;
+      final originalPlatformDispatcherOnError =
+          ui.PlatformDispatcher.instance.onError;
+
+      await tester.pumpWidget(
+        Theme(
+          data: ThemeData(platform: target),
+          child: const FindingRestaruantApp(),
+        ),
+      );
 
       // 由 navigatorKey 取得 route 之下的 context，確保讀到的是 app 實際
       // 套用的 theme，而非測試自建的外層 Theme。
@@ -33,6 +50,11 @@ void main() {
 
       // SplashPage 的 3 秒延遲不排掉會留下 pending timer，測試 framework 會報錯。
       await tester.pump(const Duration(seconds: 3));
+
+      ErrorWidget.builder = originalErrorWidgetBuilder;
+      FlutterError.onError = originalFlutterErrorOnError;
+      ui.PlatformDispatcher.instance.onError =
+          originalPlatformDispatcherOnError;
     });
   }
 }


### PR DESCRIPTION
## Summary

整合 [`flutter_inspector_kit`](https://pub.dev/packages/flutter_inspector_kit)（`^1.9.0`），提供 debug-only 的 in-app 除錯儀表板（網路請求、導航追蹤、生命週期與未捕捉例外記錄），取代目前僅能沖進 console 純文字流、無法搜尋比對的 `LogInterceptor`。Closes #59。

四個接線點全部是既有掛載點加行，`kDebugMode` 全程守衛，release build 中恆為 `null`／dead code，經 tree-shaking 移除；已在實機完成 release build 驗證（AC-4～6：無喚起手勢、無 FAB、無攔截器註冊、dashboard 相關符號不存在於 release bundle）。

## 修正問題

- 開發時修 bug 全靠猜：無法量測 Yelp 搜尋請求的真實 round-trip 耗時、無法確認 header 是否真的改由 broker 供給、無法對照 Navigator 事件與 log 時序判斷 rebuild 是否觸發。
- 現有 `LogInterceptor` 只能沖 console，無法搜尋、無法比對兩次請求差異、無法在實機查看、無法匯出附在問題回報。
- Debug build 下新增兩種等價的除錯儀表板進入點：五連點喚起手勢（`FlutterInspectorMagicalTap`，包在 `PlatformApp.builder` 外層）與常駐 FAB（於 `SplashPage` 以 `inspector?.attach()` 掛載），兩者並存、互不取代。
- Dashboard 可觀察實際發出的網路請求（URL / method / 狀態碼 / 耗時 / body）與頁面導航紀錄。

## 修正方式

**Dependency**
- `pubspec.yaml` 新增 `flutter_inspector_kit: ^1.9.0`；SDK 下界由 `>=3.5.0` 提升為 `>=3.10.1`（套件要求，`pubspec.lock` 已解析至此，屬追認既成事實）。

**DI holder（`lib/di/inspector.dart`，新檔）**
- 全專案唯一頂層持有點：`final FlutterInspector? inspector = kDebugMode ? FlutterInspector(...) : null;`
- 不走 GetIt 註冊——GetIt 的動態查表會阻止 tree-shaking 證明不可達，直接威脅 release 安全。
- 建構參數：`showNetworkNotification`（debug 時網路請求跳系統通知）、`navigatorKey`（沿用既有 app navigatorKey，供通知 tap-to-open 定位 dashboard）、`captureUncaughtErrors`、`captureLifecycleEvents`、`redactSensitiveData: false`（僅影響匯出／分享／複製，不影響畫面顯示）。

**Dio 攔截器接線（`lib/api/api_clz.dart`）**
- `FlutterInspectorDioInterceptor` 於 `dioClient` 建構完成後、`kDebugMode` 分支內加入，且刻意排在既有注入 `Authorization` header 的 `InterceptorsWrapper` 之後，確保錄到的請求包含完整 header。

**進入點：五連點手勢 + navigatorObservers（`lib/main.dart`）**
- `PlatformApp` 新增 `navigatorObservers`，debug 時掛上 `inspector.navigatorObserver`。
- 既有 `builder:` 層在 debug 時外包 `FlutterInspectorMagicalTap`，透過 `navigatorKey.currentContext` 解析 `NavigatorState` 開啟 dashboard（`PlatformApp.builder` 傳入的 context 位於 Navigator 之上，無法直接用於 `showGeneralDialog`）。

**進入點：常駐 FAB（`lib/flow/splash/view/splash_page.dart`）**
- 於 `initState` 的 post-frame callback 中以 `inspector?.attach(context: context)` 掛載，使用 `SplashPage` 自身（已在 Navigator/Overlay 之下）的 context，與 `main.dart` builder 傳入的外層 context 不同來源。
- 與五連點手勢並存，作為第二個 debug-only 進入點，同受 `kDebugMode` guard 約束。

**測試修復（`test/app_theme_platform_test.dart`）**
- 回歸修復：`inspector.dart` 的 `captureUncaughtErrors: true` 會在 `FlutterInspector` 建構子內立刻 attach 三個全域 error hook（`FlutterError.onError` / `PlatformDispatcher.onError` / `ErrorWidget.builder`）。`inspector` 為頂層 lazy final，全專案只有本測試會 mount 真實 `FindingRestaruantApp`，首次求值必在此發生，導致 `flutter_test` 判定 hook 被異動而失敗。
- 修法：在該測試 case 內以 `try/finally` 記錄並手動復原三個全域 hook，避免汙染下一輪迭代（Android case）的 before/after 快照。

**文件**
- 新增 `docs/features/2026-08-05-flutter-inspector-kit-integration.md`（功能規格）與 `docs/plans/2026-08-05-flutter-inspector-kit-integration.md`（實作計畫）。

## Test plan

- [x] `flutter analyze` 維持 `No issues found!`
- [x] `flutter test` 全綠（含回歸修復的 `app_theme_platform_test.dart`）
- [x] `dart format` 通過
- [x] Debug build 實機／模擬器驗證：五連點手勢與 FAB 皆可開啟 dashboard；Network 分頁可見 Yelp 搜尋請求完整欄位；Navigator 分頁可見「列表 → 詳情 → 返回」三筆導航事件
- [x] Release build 實機安裝驗證：所有畫面五連點無反應、無 FAB 常駐、Dio 攔截器與 navigator observer 未註冊、dashboard 相關符號經 tree-shaking 不存在於 release bundle
- [x] Release build 行為與外觀（搜尋、篩選、詳情、最愛、訪客模式）與整合前逐一比對無差異

## Summary by Sourcery

通过集成 `flutter_inspector_kit` 引入仅限调试环境使用的应用内检查器仪表板，并将其接入 Dio、导航以及启动页流程，同时确保在发布版本中完全移除该功能，并修复相关测试回归问题。

New Features:
- 添加由 `kDebugMode` 保护的 Flutter Inspector 集成，在调试构建中提供“魔法点击（magical tap）”和基于 FAB 的仪表板入口。
- 在调试构建中，通过 `flutter_inspector_kit` 暴露 Yelp API 请求以及应用导航流程的网络和导航追踪能力。

Bug Fixes:
- 通过捕获并恢复在实例化检查器时被修改的全局错误处理器，恢复 `app_theme_platform_test` 的正常运行。

Enhancements:
- 优化主应用的装配逻辑，挂载 navigator observer 和支持主题的 builder，从而可以使用全局 navigator key 调用检查器仪表板。
- 在现有授权头注入之后挂载 `FlutterInspector` 的 Dio 拦截器，以便在调试构建中捕获完整的请求/响应元数据。
- 重构启动页流程，在导航完成后挂载一个持久存在、仅在调试环境启用的检查器 FAB。
- 引入集中管理的可空 inspector 容器，以保持与 inspector 相关的代码在发布版本中可被 tree-shaking 移除。

Build:
- 将 Dart SDK 的下限提高到 `>=3.10.1` 以满足 `flutter_inspector_kit` 的要求，并将 `flutter_inspector_kit` 添加为依赖。

Documentation:
- 为 `flutter_inspector_kit` 集成添加功能规格和实现方案文档，包括范围、风险以及验证步骤。

Tests:
- 调整 `app_theme_platform_test`，保存并恢复全局 Flutter 错误 hook，以保持与检查器的未捕获错误捕获机制的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a debug-only in-app inspector dashboard via flutter_inspector_kit, wiring it into Dio, navigation, and splash flow while ensuring it is fully stripped from release builds and fixing test regressions.

New Features:
- Add a Flutter Inspector integration guarded by kDebugMode, including magical tap and FAB-based dashboard entry points in debug builds.
- Expose network and navigation tracing via flutter_inspector_kit for Yelp API requests and app navigation flows in debug builds.

Bug Fixes:
- Restore app_theme_platform_test by capturing and restoring global error handlers that are modified when the inspector is instantiated.

Enhancements:
- Refine main app wiring to attach a navigator observer and theme-aware builder that can invoke the inspector dashboard using the global navigator key.
- Attach a FlutterInspector Dio interceptor after existing authorization header injection to capture full request/response metadata in debug builds.
- Refactor splash screen flow to mount a persistent debug-only inspector FAB after navigation completes.
- Introduce a centralized nullable inspector holder to keep inspector-related code tree-shakeable from release builds.

Build:
- Raise the Dart SDK lower bound to >=3.10.1 to satisfy flutter_inspector_kit requirements and add flutter_inspector_kit as a dependency.

Documentation:
- Add feature specification and implementation plan documents for the flutter_inspector_kit integration, including scope, risks, and validation steps.

Tests:
- Adjust app_theme_platform_test to save and restore global Flutter error hooks to remain compatible with inspector’s uncaught error capturing.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增僅供開發模式使用的 Flutter Inspector 工具。
  - 可查看網路活動、未捕捉錯誤與生命週期事件。
  - 支援除錯浮動按鈕、點擊手勢開啟檢視面板及頁面導航追蹤。
  - 正式版本會自動移除相關除錯入口與功能。

- **錯誤修正**
  - 改善啟動畫面導航流程，避免頁面已卸載後仍執行導航。
  - 強化跨平台主題測試隔離性，避免測試間互相影響。

- **文件**
  - 新增 Inspector 整合規格與實作計畫文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->